### PR TITLE
api: Add simple fee esimate

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,6 +267,19 @@
                     </a>
                 </td>
             </tr>
+            <tr>
+                <td><code>/fees/estimate/&lt;blocks&gt;</code></td>
+                <td>
+                    Returns a JSON response with an estimated fee rate for the
+                    given number of blocks until confirmation. The fee rate is
+                    given as sat/kvByte, sat/kWU and sat/vByte.
+                </td>
+                <td>
+                    <a href="https://block-dn.org/fees/estimate/6">
+                        block-dn.org/fees/estimate/6
+                    </a>
+                </td>
+            </tr>
         </table>
     </section>
     <section id="test-instances">

--- a/main_test.go
+++ b/main_test.go
@@ -235,6 +235,10 @@ var testCases = []struct {
 		name: "tx-raw",
 		fn:   testTxRaw,
 	},
+	{
+		name: "fees-estimate",
+		fn:   testFeeEstimate,
+	},
 }
 
 func testErrors(t *testing.T, ctx *testContext) {
@@ -357,6 +361,16 @@ func testIndex(t *testing.T, ctx *testContext) {
 	require.Contains(
 		t, string(data), "<title>Block Delivery Network</title>",
 	)
+	require.Equal(t, "*", headers.Get(HeaderCORS))
+}
+
+func testFeeEstimate(t *testing.T, ctx *testContext) {
+	var feeRate FeeRate
+	headers := ctx.fetchJSON(t, "fees/estimate/1", &feeRate)
+	t.Logf("Got fee rate: %+v", feeRate)
+	require.EqualValues(t, 1723, feeRate.FeeSatPerKVByte)
+	require.EqualValues(t, 430, feeRate.FeeSatPerKWeight)
+	require.EqualValues(t, 1, feeRate.FeeSatPerVByte)
 	require.Equal(t, "*", headers.Get(HeaderCORS))
 }
 

--- a/models.go
+++ b/models.go
@@ -16,6 +16,12 @@ type Status struct {
 	EntriesPerSPTweakFile int32  `json:"entries_per_sptweak_file"`
 }
 
+type FeeRate struct {
+	FeeSatPerKVByte  int64 `json:"fee_sat_per_kvbyte"`
+	FeeSatPerKWeight int64 `json:"fee_sat_per_kweight"`
+	FeeSatPerVByte   int64 `json:"fee_sat_per_vbyte"`
+}
+
 type SPTweakBlock map[int32]string
 
 type SPTweakFile struct {


### PR DESCRIPTION
Light clients typically cannot estimate fees without third party help. I introduce a `fee` route here with `estimate-fee/{blocks}`, so a client may target a particular block for inclusion. The return format is little-endian bytes representing the sat/vB fee rate, which includes a reference for how to do the conversion to sat/vB from the default Bitcoin Core response. The test asserts that the response is indeed the default sat/vB fee estimate provided by Bitcoin Core (1 sat/vB)