### PR TITLE
Add some fixes to support Neutrino-like scanning in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,21 +65,24 @@ Usage:
   block-dn [flags]
 
 Flags:
-      --base-dir string           The base directory where the generated files will be stored
-      --bitcoind-host string      The host:port of the bitcoind instance to connect to (default "localhost:8332")
-      --bitcoind-pass string      The RPC password of the bitcoind instance to connect to
-      --bitcoind-user string      The RPC username of the bitcoind instance to connect to
-  -h, --help                      help for block-dn
-      --index-page string         Full path to the index.html that should be used instead of the default one that comes with the project
-      --index-sp-tweak-data       Indicates if the server should index BIP-0352 Silent Payments tweak data that allows light clients to scan the chain for inbound SP more efficiently; this requires every block since the activation of Taproot to be indexed which may take a while
-      --light-mode                Indicates if the server should run in light mode which creates no files on disk and therefore requires zero disk space; but only the status and block endpoints are available in this mode
-      --listen-addr string        The local host:port to listen on (default "localhost:8080")
-      --log-dir string            The log directory where the log file will be written (default "/home/guggero/projects/go/src/github.com/guggero/block-dn")
-      --log-level string          The log level for the logger: debug, info, warn, error, critical (default "info")
-      --regtest                   Indicates if regtest parameters should be used
-      --reorg-safe-depth uint32   The number of blocks to wait before considering a block safe from re-orgs (default 6)
-      --signet                    Indicates if signet parameters should be used
-      --testnet                   Indicates if testnet parameters should be used
-      --testnet4                  Indicates if testnet4 parameters should be used
-  -v, --version                   version for block-dn
+      --base-dir string                  The base directory where the generated files will be stored
+      --bitcoind-host string             The host:port of the bitcoind instance to connect to (default "localhost:8332")
+      --bitcoind-pass string             The RPC password of the bitcoind instance to connect to
+      --bitcoind-user string             The RPC username of the bitcoind instance to connect to
+  -h, --help                             help for block-dn
+      --index-page string                Full path to the index.html that should be used instead of the default one that comes with the project
+      --index-sp-tweak-data              Indicates if the server should index BIP-0352 Silent Payments tweak data that allows light clients to scan the chain for inbound SP more efficiently; this requires every block since the activation of Taproot to be indexed which may take a while
+      --light-mode                       Indicates if the server should run in light mode which creates no files on disk and therefore requires zero disk space; but only the status and block endpoints are available in this mode
+      --listen-addr string               The local host:port to listen on (default "localhost:8080")
+      --log-dir string                   The log directory where the log file will be written (default ".")
+      --log-level string                 The log level for the logger: debug, info, warn, error, critical (default "info")
+      --prev-out-cache-size-mib uint16   The size of the in-memory previous output cache in MiB; this cache is only used if --index-sp-tweak-data is enabled and stores previous outputs of transactions to speed up indexing of SP tweak data (default 1024)
+      --read-timeout duration            The maximum duration for reading an HTTP request (default 5s)
+      --regtest                          Indicates if regtest parameters should be used
+      --reorg-safe-depth uint32          The number of blocks to wait before considering a block safe from re-orgs (default 6)
+      --signet                           Indicates if signet parameters should be used
+      --testnet                          Indicates if testnet parameters should be used
+      --testnet4                         Indicates if testnet4 parameters should be used
+  -v, --version                          version for block-dn
+      --write-timeout duration           The maximum duration for writing an HTTP response; must be generous enough for the largest filter file to be streamed to a slow direct (non-CDN) client (default 5m0s)
 ```

--- a/cfilter-files.go
+++ b/cfilter-files.go
@@ -181,6 +181,38 @@ func (c *cFilterFiles) serializeFilters(w io.Writer, startIndex,
 	return c.serializeFiltersLocked(w, startIndex, endIndex)
 }
 
+// filterAtHeight returns the raw filter bytes for the given height if it is
+// still in the in-memory (unsealed) tail, or false if it has already been
+// pruned after sealing to disk.
+func (c *cFilterFiles) filterAtHeight(height int32) ([]byte, bool) {
+	c.RLock()
+	defer c.RUnlock()
+
+	filter, ok := c.filters[height]
+	return filter, ok
+}
+
+// filtersSize returns the exact serialized size of the var-int prefixed
+// filters in [startIndex, endIndex], or false if any of them is missing from
+// the in-memory tail.
+func (c *cFilterFiles) filtersSize(startIndex, endIndex int32) (int64, bool) {
+	c.RLock()
+	defer c.RUnlock()
+
+	var total int64
+	for j := startIndex; j <= endIndex; j++ {
+		filter, ok := c.filters[j]
+		if !ok {
+			return 0, false
+		}
+
+		total += int64(wire.VarIntSerializeSize(uint64(len(filter)))) +
+			int64(len(filter))
+	}
+
+	return total, true
+}
+
 func (c *cFilterFiles) serializeFiltersLocked(w io.Writer, startIndex,
 	endIndex int32) error {
 

--- a/handlers.go
+++ b/handlers.go
@@ -204,6 +204,8 @@ func (s *server) statusRequestHandler(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	status := &Status{
+		Version:               version,
+		Commit:                Commit,
 		ChainGenesisHash:      s.chainParams.GenesisHash.String(),
 		ChainName:             s.chainParams.Name,
 		BestBlockHeight:       bestHeight,

--- a/handlers.go
+++ b/handlers.go
@@ -631,7 +631,7 @@ func (s *server) blockSpentTxOutsRequestHandler(w http.ResponseWriter,
 		s.chainCfg.Host, blockHash.String(), format)
 
 	client := &http.Client{
-		Timeout: defaultTimeout,
+		Timeout: backendRequestTimeout,
 	}
 
 	req, err := http.NewRequestWithContext(
@@ -767,7 +767,7 @@ func (s *server) utxoRequestHandler(w http.ResponseWriter, r *http.Request) {
 		s.chainCfg.Host, mempool, txHash.String(), vOut, format)
 
 	client := &http.Client{
-		Timeout: defaultTimeout,
+		Timeout: backendRequestTimeout,
 	}
 
 	req, err := http.NewRequestWithContext(

--- a/handlers.go
+++ b/handlers.go
@@ -141,6 +141,10 @@ func (s *server) createRouter() *mux.Router {
 	)
 	router.HandleFunc("/filters/{height:[0-9]+}", s.filtersRequestHandler)
 	router.HandleFunc(
+		"/filters/single/{height:[0-9]+}",
+		s.filterSingleRequestHandler,
+	)
+	router.HandleFunc(
 		"/sp/tweak-data/{height:[0-9]+}",
 		s.spTweakDataRequestHandler,
 	)
@@ -220,7 +224,7 @@ func (s *server) headersRequestHandler(w http.ResponseWriter, r *http.Request) {
 	s.heightBasedRequestHandler(
 		w, r, HeaderFileDir, HeaderFileNamePattern,
 		int64(s.headersPerFile), s.headerFiles.serializeHeaders,
-		s.headerFiles,
+		s.headerFiles.headersSize, s.headerFiles,
 	)
 }
 
@@ -254,7 +258,7 @@ func (s *server) filterHeadersRequestHandler(w http.ResponseWriter,
 	s.heightBasedRequestHandler(
 		w, r, HeaderFileDir, FilterHeaderFileNamePattern,
 		int64(s.headersPerFile), s.headerFiles.serializeFilterHeaders,
-		s.headerFiles,
+		s.headerFiles.filterHeadersSize, s.headerFiles,
 	)
 }
 
@@ -284,8 +288,75 @@ func (s *server) filtersRequestHandler(w http.ResponseWriter, r *http.Request) {
 	s.heightBasedRequestHandler(
 		w, r, FilterFileDir, FilterFileNamePattern,
 		int64(s.filtersPerFile), s.cFilterFiles.serializeFilters,
-		s.cFilterFiles,
+		s.cFilterFiles.filtersSize, s.cFilterFiles,
 	)
+}
+
+// filterSingleRequestHandler serves /filters/single/{height}: the raw BIP158
+// basic filter of a single block, without a var-int length prefix (the length
+// is the Content-Length). The batch /filters/{height} route only accepts
+// file-aligned start heights, which would force a tip-following client to
+// re-download the whole unsealed tail file for every new block; this endpoint
+// is the cheap alternative. It works in light mode too, since it's backed by
+// the node's own filter index rather than the on-disk files.
+func (s *server) filterSingleRequestHandler(w http.ResponseWriter,
+	r *http.Request) {
+
+	height, err := parseRequestParamInt64(r, "height")
+	if err != nil {
+		sendError(w, status400, err)
+		return
+	}
+
+	// Serve from the in-memory tail if this height hasn't been sealed to
+	// disk yet. This avoids a backend round trip for the hot tip range.
+	if !s.lightMode && s.cFilterFiles.isStartupComplete() {
+		current := int64(s.cFilterFiles.getCurrentHeight())
+		if height > current {
+			sendError(w, status400, fmt.Errorf("start height %d "+
+				"is greater than current height %d", height,
+				current))
+			return
+		}
+
+		if filter, ok := s.cFilterFiles.filterAtHeight(
+			int32(height),
+		); ok {
+			sendRawBytes(w, filter, maxAgeMemory)
+			return
+		}
+	}
+
+	// The height is in the sealed range (or we're in light mode), so ask
+	// the backend's filter index directly. Sealed heights are safe to
+	// cache at the disk tier; anything within the reorg window stays at
+	// the memory tier.
+	hash, err := s.h2hCache.getBlockHash(int32(height))
+	if err != nil {
+		sendError(w, status400, fmt.Errorf("invalid height"))
+		return
+	}
+
+	filter, err := s.chain.GetBlockFilter(*hash, &filterBasic)
+	if err != nil {
+		sendError(w, status500, err)
+		return
+	}
+
+	filterBytes, err := hex.DecodeString(filter.Filter)
+	if err != nil {
+		sendError(w, status500, err)
+		return
+	}
+
+	maxAge := maxAgeMemory
+	if !s.lightMode &&
+		int64(s.cFilterFiles.getLastSealedHeight()) >= height {
+
+		maxAge = maxAgeDisk
+	}
+
+	sendRawBytes(w, filterBytes, maxAge)
 }
 
 func (s *server) spTweakDataRequestHandler(w http.ResponseWriter,
@@ -296,10 +367,12 @@ func (s *server) spTweakDataRequestHandler(w http.ResponseWriter,
 		return
 	}
 
+	// SP tweak data is variable-size JSON, so no size callback: computing
+	// it would mean serializing twice.
 	s.heightBasedRequestHandler(
 		w, r, SPTweakFileDir, SPTweakFileNamePattern,
 		int64(s.spTweaksPerFile), s.spTweakFiles.serializeSPTweakData,
-		s.spTweakFiles,
+		nil, s.spTweakFiles,
 	)
 }
 
@@ -346,6 +419,7 @@ func (s *server) estimateFeeRequestHandler(w http.ResponseWriter,
 func (s *server) heightBasedRequestHandler(w http.ResponseWriter,
 	r *http.Request, subDir, fileNamePattern string, entriesPerFile int64,
 	serializeCb func(w io.Writer, startIndex, endIndex int32) error,
+	sizeCb func(startIndex, endIndex int32) (int64, bool),
 	processor blockProcessor) {
 
 	// These kinds of requests aren't available in light mode.
@@ -379,13 +453,13 @@ func (s *server) heightBasedRequestHandler(w http.ResponseWriter,
 	if fileExists(fileName) {
 		addCorsHeaders(w)
 		addCacheHeaders(w, maxAgeDisk)
-		w.WriteHeader(http.StatusOK)
-		if err := streamFile(w, fileName); err != nil {
-			// We've already written response headers and possibly
-			// part of the body. We can't change status now;
-			// log and stop.
-			log.Errorf("Error while streaming file: %v", err)
-		}
+
+		// Serving the sealed file through http.ServeContent gives
+		// clients Content-Length, Last-Modified/If-Modified-Since and
+		// HTTP range requests — the latter lets a browser client
+		// resume a large filter file download instead of restarting
+		// it.
+		serveFile(w, r, fileName)
 
 		return
 	}
@@ -399,11 +473,21 @@ func (s *server) heightBasedRequestHandler(w http.ResponseWriter,
 	}
 
 	// The requested start height wasn't yet in a file, so we need to
-	// stream the headers from memory.
+	// stream the headers from memory. The exact response size is known
+	// for fixed-size entries (and cheaply computable for filters), so
+	// announce it where possible to let clients detect truncation.
+	endHeight := processor.getCurrentHeight()
 	addCorsHeaders(w)
 	addCacheHeaders(w, maxAgeMemory)
+	if sizeCb != nil {
+		if size, ok := sizeCb(int32(startHeight), endHeight); ok {
+			w.Header().Set(
+				"Content-Length", strconv.FormatInt(size, 10),
+			)
+		}
+	}
 	w.WriteHeader(http.StatusOK)
-	err = serializeCb(w, int32(startHeight), processor.getCurrentHeight())
+	err = serializeCb(w, int32(startHeight), endHeight)
 	if err != nil {
 		log.Errorf("Error serializing: %v", err)
 	}
@@ -867,6 +951,10 @@ func sendBinary(w http.ResponseWriter, v serializable, maxAge time.Duration) {
 func sendRawBytes(w http.ResponseWriter, payload []byte, maxAge time.Duration) {
 	addCacheHeaders(w, maxAge)
 	addCorsHeaders(w)
+
+	// The payload is fully known here, so announce its length; explicitly
+	// calling WriteHeader below disables Go's automatic inference.
+	w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
 	w.WriteHeader(http.StatusOK)
 	_, err := w.Write(payload)
 	if err != nil {
@@ -1000,4 +1088,34 @@ func streamFile(w io.Writer, fileName string) error {
 
 	_, err = io.Copy(w, f)
 	return err
+}
+
+// serveFile serves a single sealed file via http.ServeContent, which handles
+// Content-Length, Last-Modified/If-Modified-Since and range requests. Unlike
+// streamFile it must own the status code (206 for ranges), so callers must
+// not call WriteHeader themselves.
+func serveFile(w http.ResponseWriter, r *http.Request, fileName string) {
+	f, err := os.Open(fileName)
+	if err != nil {
+		log.Errorf("Error opening file %s: %v", fileName, err)
+		sendError(w, status500, fmt.Errorf("error reading file"))
+		return
+	}
+
+	defer func(f *os.File) {
+		err := f.Close()
+		if err != nil {
+			log.Errorf("Error closing file %s: %v", fileName, err)
+		}
+	}(f)
+
+	stat, err := f.Stat()
+	if err != nil {
+		log.Errorf("Error getting file info %s: %v", fileName, err)
+		sendError(w, status500, fmt.Errorf("error reading file"))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	http.ServeContent(w, r, stat.Name(), stat.ModTime(), f)
 }

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -176,5 +177,88 @@ func TestCheckImportPreconditions(t *testing.T) {
 		// Default Code is 200 when WriteHeader hasn't been called.
 		require.Equal(t, 200, rec.Code)
 		require.Empty(t, rec.Body.String())
+	})
+}
+
+// TestSizeHelpers checks the exact-size computations used for the memory-tier
+// Content-Length header.
+func TestSizeHelpers(t *testing.T) {
+	hf := &headerFiles{}
+
+	size, ok := hf.headersSize(0, 9)
+	require.True(t, ok)
+	require.EqualValues(t, 10*80, size)
+
+	size, ok = hf.filterHeadersSize(100, 100)
+	require.True(t, ok)
+	require.EqualValues(t, 32, size)
+
+	// An empty range can't be sized.
+	_, ok = hf.headersSize(5, 4)
+	require.False(t, ok)
+
+	cf := &cFilterFiles{
+		filters: map[int32][]byte{
+			0: make([]byte, 10),
+			1: make([]byte, 300),
+		},
+	}
+
+	// 10-byte filter has a 1-byte var-int prefix, the 300-byte one a
+	// 3-byte prefix (0xfd + uint16).
+	size, ok = cf.filtersSize(0, 1)
+	require.True(t, ok)
+	require.EqualValues(t, 1+10+3+300, size)
+
+	// A missing height means the size can't be computed.
+	_, ok = cf.filtersSize(0, 2)
+	require.False(t, ok)
+}
+
+// TestFilterSingleMemoryPath checks the /filters/single/{height} route for
+// heights that are still in the unsealed in-memory tail, including the
+// out-of-bounds rejection. The sealed (backend RPC) path is covered by the
+// bitcoind integration test.
+func TestFilterSingleMemoryPath(t *testing.T) {
+	filterBytes := []byte{0x01, 0x02, 0x03, 0x04}
+
+	cf := &cFilterFiles{
+		filters: map[int32][]byte{5: filterBytes},
+	}
+	cf.startupComplete.Store(true)
+	cf.currentHeight.Store(5)
+	cf.lastSealedHeight.Store(-1)
+
+	s := &server{cFilterFiles: cf}
+	router := s.createRouter()
+
+	t.Run("tail filter served from memory", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(
+			http.MethodGet, "/filters/single/5", nil,
+		)
+		router.ServeHTTP(rec, req)
+
+		require.Equal(t, 200, rec.Code)
+		require.Equal(t, filterBytes, rec.Body.Bytes())
+		require.Equal(t, "4", rec.Header().Get("Content-Length"))
+		require.Equal(
+			t, "public, max-age=60",
+			rec.Header().Get(HeaderCache),
+		)
+		require.Equal(t, "*", rec.Header().Get(HeaderCORS))
+	})
+
+	t.Run("height above tip rejected", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(
+			http.MethodGet, "/filters/single/6", nil,
+		)
+		router.ServeHTTP(rec, req)
+
+		require.Equal(t, 400, rec.Code)
+		require.Contains(
+			t, rec.Body.String(), "greater than current height",
+		)
 	})
 }

--- a/header-files.go
+++ b/header-files.go
@@ -215,6 +215,28 @@ func (h *headerFiles) writeFilterHeaders(fileName string, startIndex,
 	return nil
 }
 
+// headersSize returns the exact serialized size of the block headers in
+// [startIndex, endIndex]: headers are fixed-size, so this is pure arithmetic.
+func (h *headerFiles) headersSize(startIndex, endIndex int32) (int64, bool) {
+	if endIndex < startIndex {
+		return 0, false
+	}
+
+	return int64(endIndex-startIndex+1) * wire.MaxBlockHeaderPayload, true
+}
+
+// filterHeadersSize returns the exact serialized size of the filter headers
+// in [startIndex, endIndex]; each one is a 32-byte hash.
+func (h *headerFiles) filterHeadersSize(startIndex, endIndex int32) (int64,
+	bool) {
+
+	if endIndex < startIndex {
+		return 0, false
+	}
+
+	return int64(endIndex-startIndex+1) * chainhash.HashSize, true
+}
+
 // serializeFilterHeaders writes raw filter headers for [startIndex, endIndex]
 // to w. Acquires the read lock; safe to call from request handlers.
 func (h *headerFiles) serializeFilterHeaders(w io.Writer, startIndex,

--- a/index.html
+++ b/index.html
@@ -254,6 +254,24 @@
                 </td>
             </tr>
             <tr>
+                <td><code>/filters/single/&lt;block&gt;</code></td>
+                <td>
+                    Returns the raw compact filter (BIP-0158 basic filter) of
+                    a single block, without a length prefix (the length is the
+                    <code>Content-Length</code>). Useful for tip-following
+                    clients that would otherwise need to re-download the whole
+                    unsealed batch file for every new block. Blocks that are
+                    already sealed to disk are long-cached (disk tier), blocks
+                    within the re-org window are short-cached (memory tier).
+                    Also available in light mode.
+                </td>
+                <td>
+                    <a href="https://block-dn.org/filters/single/802123">
+                        block-dn.org/filters/single/802123
+                    </a>
+                </td>
+            </tr>
+            <tr>
                 <td><code>/sp/tweak-data/&lt;start_block&gt;</code></td>
                 <td>
                     Returns a JSON file containing Silent Payment tweak data

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	version = "1.3.2"
+	version = "1.3.3"
 
 	defaultListenPort = 8080
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/rpcclient"
@@ -53,6 +54,9 @@ type mainCommand struct {
 	listenAddr string
 
 	reOrgSafeDepth uint32
+
+	readTimeout  time.Duration
+	writeTimeout time.Duration
 
 	bitcoindConfig *rpcclient.ConnConfig
 	cmd            *cobra.Command
@@ -148,7 +152,8 @@ func main() {
 				cc.listenAddr, cc.bitcoindConfig, chainParams,
 				cc.reOrgSafeDepth, headersPerFile,
 				filtersPerFile, spTweaksPerFile,
-				cc.prevOutCacheSizeMiB,
+				cc.prevOutCacheSizeMiB, cc.readTimeout,
+				cc.writeTimeout,
 			)
 			err := server.start()
 			if err != nil {
@@ -255,6 +260,16 @@ func main() {
 		defaultMainnetReOrgSafeDepth,
 		"The number of blocks to wait before considering a block "+
 			"safe from re-orgs",
+	)
+	cc.cmd.PersistentFlags().DurationVar(
+		&cc.readTimeout, "read-timeout", defaultReadTimeout,
+		"The maximum duration for reading an HTTP request",
+	)
+	cc.cmd.PersistentFlags().DurationVar(
+		&cc.writeTimeout, "write-timeout", defaultWriteTimeout,
+		"The maximum duration for writing an HTTP response; must be "+
+			"generous enough for the largest filter file to be "+
+			"streamed to a slow direct (non-CDN) client",
 	)
 
 	if err := cc.cmd.Execute(); err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -229,6 +229,14 @@ var testCases = []struct {
 		fn:   testFilterHeadersImportLatest,
 	},
 	{
+		name: "filter-single",
+		fn:   testFilterSingle,
+	},
+	{
+		name: "range-requests",
+		fn:   testRangeRequests,
+	},
+	{
 		name: "sp-tweak-data",
 		fn:   testSPTweakData,
 	},
@@ -1187,4 +1195,120 @@ func waitBackendSync(t *testing.T, backend *rpcclient.Client,
 		return nil
 	}, syncTimeout)
 	require.NoError(t, err)
+}
+
+// fetchWithHeaders performs a GET with extra request headers and returns the
+// body, response headers and status code.
+func (ctx *testContext) fetchWithHeaders(t *testing.T, endpoint string,
+	reqHeaders map[string]string) ([]byte, http.Header, int) {
+
+	url := fmt.Sprintf("http://%s/%s", ctx.server.listenAddr, endpoint)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	require.NoError(t, err)
+	for k, v := range reqHeaders {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, resp.Body.Close())
+	}()
+
+	body := new(bytes.Buffer)
+	_, err = body.ReadFrom(resp.Body)
+	require.NoError(t, err)
+
+	return body.Bytes(), resp.Header, resp.StatusCode
+}
+
+// expectedFilter fetches the BIP158 basic filter for the given height straight
+// from the backend, as the expected value for endpoint assertions.
+func (ctx *testContext) expectedFilter(t *testing.T, height int64) []byte {
+	blockHash, err := ctx.backend.GetBlockHash(height)
+	require.NoError(t, err)
+
+	filter, err := ctx.backend.GetBlockFilter(*blockHash, &filterBasic)
+	require.NoError(t, err)
+
+	filterBytes, err := hex.DecodeString(filter.Filter)
+	require.NoError(t, err)
+
+	return filterBytes
+}
+
+// testFilterSingle checks the /filters/single/{height} endpoint: the sealed
+// (backend-served, disk cache tier) path, the in-memory tail path and the
+// out-of-bounds error.
+func testFilterSingle(t *testing.T, ctx *testContext) {
+	// Height 100 is long sealed (the first filter file covers heights
+	// 0..1999 and more than 2000+reorg-safe-depth blocks were mined), so
+	// it must come back with the disk cache tier.
+	body, headers, status := ctx.fetchBinaryWithStatus(
+		t, "filters/single/100",
+	)
+	require.Equal(t, 200, status)
+	require.Equal(t, ctx.expectedFilter(t, 100), body)
+	require.Equal(t, cacheDisk, headers.Get(HeaderCache))
+	require.Equal(t, "*", headers.Get(HeaderCORS))
+	require.Equal(
+		t, strconv.Itoa(len(body)), headers.Get("Content-Length"),
+	)
+
+	// The current tip is still in the in-memory tail, so it must be
+	// served at the memory tier.
+	tipHeight, _ := ctx.bestBlock(t)
+	body, headers, status = ctx.fetchBinaryWithStatus(
+		t, fmt.Sprintf("filters/single/%d", tipHeight),
+	)
+	require.Equal(t, 200, status)
+	require.Equal(t, ctx.expectedFilter(t, int64(tipHeight)), body)
+	require.Equal(t, cacheMemory, headers.Get(HeaderCache))
+
+	// A height above the tip is rejected.
+	_, _, status = ctx.fetchBinaryWithStatus(
+		t, fmt.Sprintf("filters/single/%d", tipHeight+1),
+	)
+	require.Equal(t, 400, status)
+}
+
+// testRangeRequests checks that sealed files are served with Content-Length
+// and support HTTP range requests, and that memory-tier responses of
+// fixed-size entries announce an exact Content-Length.
+func testRangeRequests(t *testing.T, ctx *testContext) {
+	// A sealed header file has a known exact size.
+	fullSize := DefaultRegtestHeadersPerFile * headerSize
+	body, headers := ctx.fetchBinary(t, "headers/0")
+	require.Len(t, body, fullSize)
+	require.Equal(
+		t, strconv.Itoa(fullSize), headers.Get("Content-Length"),
+	)
+	require.Equal(t, "bytes", headers.Get("Accept-Ranges"))
+	require.NotEmpty(t, headers.Get("Last-Modified"))
+
+	// A range request for the second header must return exactly that
+	// header with a 206 status.
+	rangeBody, rangeHeaders, status := ctx.fetchWithHeaders(
+		t, "headers/0", map[string]string{"Range": "bytes=80-159"},
+	)
+	require.Equal(t, http.StatusPartialContent, status)
+	require.Len(t, rangeBody, 80)
+	require.Equal(t, body[80:160], rangeBody)
+	require.Equal(t, "80", rangeHeaders.Get("Content-Length"))
+
+	// The memory-tier headers response (unsealed tail) announces its
+	// exact size too: entries are fixed-size 80-byte headers.
+	tipHeight, _ := ctx.bestBlock(t)
+	const startHeight = DefaultRegtestHeadersPerFile
+	tailBody, tailHeaders := ctx.fetchBinary(
+		t, fmt.Sprintf("headers/%d", startHeight),
+	)
+	expectedLen := (int(tipHeight) - startHeight + 1) * headerSize
+	require.Len(t, tailBody, expectedLen)
+	require.Equal(
+		t, strconv.Itoa(expectedLen),
+		tailHeaders.Get("Content-Length"),
+	)
+	require.Equal(t, cacheMemory, tailHeaders.Get(HeaderCache))
 }

--- a/main_test.go
+++ b/main_test.go
@@ -992,7 +992,8 @@ func TestBlockDN(t *testing.T) {
 		false, true, dataDir, listenAddr, &backendCfg,
 		unittest.NetParams, 6, DefaultRegtestHeadersPerFile,
 		DefaultRegtestFiltersPerFile, DefaultRegtestSPTweaksPerFile,
-		DefaultPrevOutCacheMiBytes,
+		DefaultPrevOutCacheMiBytes, defaultReadTimeout,
+		defaultWriteTimeout,
 	)
 	ctx := &testContext{
 		miner:   miner,
@@ -1097,7 +1098,7 @@ func newBitcoind(t *testing.T, logdir string,
 			MempoolPollingInterval: pollInterval,
 			RPCBatchInterval:       pollInterval,
 			RPCBatchSize:           1,
-			ZMQReadDeadline:        defaultTimeout,
+			ZMQReadDeadline:        defaultReadTimeout,
 		},
 	}
 

--- a/models.go
+++ b/models.go
@@ -3,6 +3,8 @@ package main
 import "fmt"
 
 type Status struct {
+	Version               string `json:"version"`
+	Commit                string `json:"commit"`
 	ChainGenesisHash      string `json:"chain_genesis_hash"`
 	ChainName             string `json:"chain_name"`
 	BestBlockHeight       int32  `json:"best_block_height"`

--- a/reorg_safe_test.go
+++ b/reorg_safe_test.go
@@ -121,6 +121,7 @@ func startReorgTestServer(t *testing.T,
 		unittest.NetParams, params.reOrgSafeDepth,
 		params.headersPerFile, params.filtersPerFile,
 		params.spTweaksPerFile, DefaultPrevOutCacheMiBytes,
+		defaultReadTimeout, defaultWriteTimeout,
 	)
 	ctx := &testContext{
 		miner:   miner,

--- a/server.go
+++ b/server.go
@@ -16,7 +16,21 @@ import (
 )
 
 var (
-	defaultTimeout    = 5 * time.Second
+	// defaultReadTimeout bounds how long reading a request (tiny GETs)
+	// may take.
+	defaultReadTimeout = 5 * time.Second
+
+	// defaultWriteTimeout bounds how long writing a response may take.
+	// The largest files served are ~58 MiB filter files, which a direct
+	// (non-CDN) client on a slow link can easily need more than a few
+	// seconds for, so this is much more generous than the read timeout.
+	// Both are configurable via --read-timeout / --write-timeout.
+	defaultWriteTimeout = 5 * time.Minute
+
+	// backendRequestTimeout bounds proxied REST requests to the local
+	// bitcoind backend.
+	backendRequestTimeout = 5 * time.Second
+
 	blockPollInterval = time.Second
 
 	errServerShutdown = errors.New("server shutting down")
@@ -30,6 +44,8 @@ type server struct {
 	chainCfg         *rpcclient.ConnConfig
 	chainParams      *chaincfg.Params
 	reOrgSafeDepth   uint32
+	readTimeout      time.Duration
+	writeTimeout     time.Duration
 	chain            *rpcclient.Client
 	router           *mux.Router
 	httpServer       *http.Server
@@ -52,7 +68,17 @@ type server struct {
 func newServer(lightMode, indexSPTweakData bool, baseDir, listenAddr string,
 	chainCfg *rpcclient.ConnConfig, chainParams *chaincfg.Params,
 	reOrgSafeDepth uint32, headersPerFile, filtersPerFile,
-	spTweaksPerFile int32, spTweakCacheSizeMiB uint16) *server {
+	spTweaksPerFile int32, spTweakCacheSizeMiB uint16, readTimeout,
+	writeTimeout time.Duration) *server {
+
+	// A zero timeout would disable the protection entirely; fall back to
+	// the defaults instead so misconfiguration fails safe.
+	if readTimeout <= 0 {
+		readTimeout = defaultReadTimeout
+	}
+	if writeTimeout <= 0 {
+		writeTimeout = defaultWriteTimeout
+	}
 
 	s := &server{
 		lightMode:        lightMode,
@@ -62,6 +88,8 @@ func newServer(lightMode, indexSPTweakData bool, baseDir, listenAddr string,
 		chainCfg:         chainCfg,
 		chainParams:      chainParams,
 		reOrgSafeDepth:   reOrgSafeDepth,
+		readTimeout:      readTimeout,
+		writeTimeout:     writeTimeout,
 
 		headersPerFile:      headersPerFile,
 		filtersPerFile:      filtersPerFile,
@@ -136,8 +164,8 @@ func (s *server) start() error {
 	s.httpServer = &http.Server{
 		Addr:         s.listenAddr,
 		Handler:      s.router,
-		WriteTimeout: defaultTimeout,
-		ReadTimeout:  defaultTimeout,
+		WriteTimeout: s.writeTimeout,
+		ReadTimeout:  s.readTimeout,
 	}
 	s.errs.Start()
 


### PR DESCRIPTION
Working on a demo page of how to use `block-dn` for a Neutrino-like in-browser scanner.
A couple of things needed to be optimized to achieve that:
 - Add proper read and write timeouts, make them configurable (set low timeouts when behind CDN, larger timeouts when allowing direct connections from potentially slow clients).
 - Add `Content-Length` field, support range queries.
 - Add new `/filters/single/<block>` endpoint for easy tip-following.