### PR TITLE
Optimize Silent Payment calculation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,10 +43,8 @@ jobs:
       - name: check code format
         run: make fmt-check
 
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
-        with:
-          version: '${{ env.LINT_VERSION }}'
+      - name: lint
+        run: make lint
 
   ########################
   # run unit tests

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Flags:
       --bitcoind-user string      The RPC username of the bitcoind instance to connect to
   -h, --help                      help for block-dn
       --index-page string         Full path to the index.html that should be used instead of the default one that comes with the project
-      --index-sp-tweak-data       Indicates if the server should index BIP-0352 Silent Payments tweak data that allows light clients to scan the chain for inbound SP more efficiently; this requires every block since the activation of Taproot to be indexed which may take a while; requires bitcoind v25.0 or later, and setting rest=1 on bitcoind v30.0 or later speeds up the indexing significantly
+      --index-sp-tweak-data       Indicates if the server should index BIP-0352 Silent Payments tweak data that allows light clients to scan the chain for inbound SP more efficiently; this requires every block since the activation of Taproot to be indexed which may take a while; requires bitcoind v30.0 or later with the REST API enabled (rest=1)
       --light-mode                Indicates if the server should run in light mode which creates no files on disk and therefore requires zero disk space; but only the status and block endpoints are available in this mode
       --listen-addr string        The local host:port to listen on (default "localhost:8080")
       --log-dir string            The log directory where the log file will be written (default ".")

--- a/README.md
+++ b/README.md
@@ -65,24 +65,23 @@ Usage:
   block-dn [flags]
 
 Flags:
-      --base-dir string                  The base directory where the generated files will be stored
-      --bitcoind-host string             The host:port of the bitcoind instance to connect to (default "localhost:8332")
-      --bitcoind-pass string             The RPC password of the bitcoind instance to connect to
-      --bitcoind-user string             The RPC username of the bitcoind instance to connect to
-  -h, --help                             help for block-dn
-      --index-page string                Full path to the index.html that should be used instead of the default one that comes with the project
-      --index-sp-tweak-data              Indicates if the server should index BIP-0352 Silent Payments tweak data that allows light clients to scan the chain for inbound SP more efficiently; this requires every block since the activation of Taproot to be indexed which may take a while
-      --light-mode                       Indicates if the server should run in light mode which creates no files on disk and therefore requires zero disk space; but only the status and block endpoints are available in this mode
-      --listen-addr string               The local host:port to listen on (default "localhost:8080")
-      --log-dir string                   The log directory where the log file will be written (default ".")
-      --log-level string                 The log level for the logger: debug, info, warn, error, critical (default "info")
-      --prev-out-cache-size-mib uint16   The size of the in-memory previous output cache in MiB; this cache is only used if --index-sp-tweak-data is enabled and stores previous outputs of transactions to speed up indexing of SP tweak data (default 1024)
-      --read-timeout duration            The maximum duration for reading an HTTP request (default 5s)
-      --regtest                          Indicates if regtest parameters should be used
-      --reorg-safe-depth uint32          The number of blocks to wait before considering a block safe from re-orgs (default 6)
-      --signet                           Indicates if signet parameters should be used
-      --testnet                          Indicates if testnet parameters should be used
-      --testnet4                         Indicates if testnet4 parameters should be used
-  -v, --version                          version for block-dn
-      --write-timeout duration           The maximum duration for writing an HTTP response; must be generous enough for the largest filter file to be streamed to a slow direct (non-CDN) client (default 5m0s)
+      --base-dir string           The base directory where the generated files will be stored
+      --bitcoind-host string      The host:port of the bitcoind instance to connect to (default "localhost:8332")
+      --bitcoind-pass string      The RPC password of the bitcoind instance to connect to
+      --bitcoind-user string      The RPC username of the bitcoind instance to connect to
+  -h, --help                      help for block-dn
+      --index-page string         Full path to the index.html that should be used instead of the default one that comes with the project
+      --index-sp-tweak-data       Indicates if the server should index BIP-0352 Silent Payments tweak data that allows light clients to scan the chain for inbound SP more efficiently; this requires every block since the activation of Taproot to be indexed which may take a while; requires bitcoind v25.0 or later, and setting rest=1 on bitcoind v30.0 or later speeds up the indexing significantly
+      --light-mode                Indicates if the server should run in light mode which creates no files on disk and therefore requires zero disk space; but only the status and block endpoints are available in this mode
+      --listen-addr string        The local host:port to listen on (default "localhost:8080")
+      --log-dir string            The log directory where the log file will be written (default ".")
+      --log-level string          The log level for the logger: debug, info, warn, error, critical (default "info")
+      --read-timeout duration     The maximum duration for reading an HTTP request (default 5s)
+      --regtest                   Indicates if regtest parameters should be used
+      --reorg-safe-depth uint32   The number of blocks to wait before considering a block safe from re-orgs (default 6)
+      --signet                    Indicates if signet parameters should be used
+      --testnet                   Indicates if testnet parameters should be used
+      --testnet4                  Indicates if testnet4 parameters should be used
+  -v, --version                   version for block-dn
+      --write-timeout duration    The maximum duration for writing an HTTP response; must be generous enough for the largest filter file to be streamed to a slow direct (non-CDN) client (default 5m0s)
 ```

--- a/block-prevouts.go
+++ b/block-prevouts.go
@@ -42,6 +42,12 @@ const (
 	// corrupt length prefix. A block can't contain more transactions (or
 	// inputs) than its serialized size in bytes.
 	maxSpentTxOutsPerBlock = wire.MaxBlockPayload
+
+	// minSPTweakBackendVersion is the minimum bitcoind version (in the
+	// numeric format reported by getnetworkinfo) we require for indexing
+	// SP tweak data: v30.0 is the first version that serves a block's
+	// spent outputs through the /rest/spenttxouts endpoint.
+	minSPTweakBackendVersion = 300_000
 )
 
 // getBlockScriptPubKey is the subset of the scriptPubKey JSON object of the
@@ -198,6 +204,35 @@ func (f *blockPrevOutFetcher) probeREST() {
 	log.Infof("Using the backend's REST API at %s to fetch blocks and "+
 		"spent outputs", f.restURL)
 	f.useREST = true
+}
+
+// requireREST probes the backend's REST API and returns an error if it isn't
+// available. There is no RPC call that reports which options the backend was
+// started with, so a test call against the REST API is the only way to find
+// out whether it is enabled.
+func (f *blockPrevOutFetcher) requireREST() error {
+	f.probeOnce.Do(f.probeREST)
+
+	if !f.useREST {
+		return fmt.Errorf("the backend's REST API is not reachable "+
+			"at %s; set rest=1 in the bitcoind configuration",
+			f.restURL)
+	}
+
+	return nil
+}
+
+// verifySPTweakBackendVersion returns an error if the given backend version
+// (in the numeric format reported by getnetworkinfo) is too old for indexing
+// SP tweak data.
+func verifySPTweakBackendVersion(version int32) error {
+	if version < minSPTweakBackendVersion {
+		return fmt.Errorf("indexing SP tweak data requires bitcoind "+
+			"v30.0 or later, but the backend reports version %d",
+			version)
+	}
+
+	return nil
 }
 
 // restGet performs a GET request against the given REST path on the backend

--- a/block-prevouts.go
+++ b/block-prevouts.go
@@ -48,6 +48,14 @@ const (
 	// SP tweak data: v30.0 is the first version that serves a block's
 	// spent outputs through the /rest/spenttxouts endpoint.
 	minSPTweakBackendVersion = 300_000
+
+	// prefetchDepth is the number of blocks the prefetcher keeps in
+	// flight ahead of the block currently being processed, hiding the
+	// fetch latency behind the tweak computation of the current block.
+	// bitcoind answers REST requests from its RPC worker thread pool
+	// (rpcthreads, 4 by default), so a substantially higher depth only
+	// helps if the backend's pool is raised as well.
+	prefetchDepth = 8
 )
 
 // getBlockScriptPubKey is the subset of the scriptPubKey JSON object of the
@@ -148,12 +156,23 @@ func backendRESTURL(chainCfg *rpcclient.ConnConfig) string {
 func newBlockPrevOutFetcher(chain *rpcclient.Client,
 	chainCfg *rpcclient.ConnConfig) *blockPrevOutFetcher {
 
+	httpClient := &http.Client{
+		Timeout: restRequestTimeout,
+	}
+
+	// Allow as many keep-alive connections to the backend as we have
+	// concurrent block fetches, so the prefetcher doesn't churn through
+	// short-lived TCP connections.
+	if transport, ok := http.DefaultTransport.(*http.Transport); ok {
+		transport = transport.Clone()
+		transport.MaxIdleConnsPerHost = prefetchDepth + 1
+		httpClient.Transport = transport
+	}
+
 	return &blockPrevOutFetcher{
-		chain:   chain,
-		restURL: backendRESTURL(chainCfg),
-		httpClient: &http.Client{
-			Timeout: restRequestTimeout,
-		},
+		chain:      chain,
+		restURL:    backendRESTURL(chainCfg),
+		httpClient: httpClient,
 	}
 }
 
@@ -204,6 +223,106 @@ func (f *blockPrevOutFetcher) probeREST() {
 	log.Infof("Using the backend's REST API at %s to fetch blocks and "+
 		"spent outputs", f.restURL)
 	f.useREST = true
+}
+
+// prefetchResult is the outcome of a single background block fetch.
+type prefetchResult struct {
+	block *blockWithPrevOuts
+	err   error
+}
+
+// prefetchedBlock tracks a single background block fetch, together with the
+// block hash the fetch was started for, so a reorg that happened between
+// scheduling and consumption can be detected.
+type prefetchedBlock struct {
+	hash   chainhash.Hash
+	result chan prefetchResult
+}
+
+// blockPrefetcher hides the fetch latency of sequential block processing by
+// keeping the fetches for the next few heights running in the background
+// while the current block is being processed.
+//
+// It must only be used from a single goroutine; the background fetches only
+// ever touch their own result channel, never the pending map.
+type blockPrefetcher struct {
+	// fetchSingle fetches a single block. Held as a function reference
+	// so tests can run the prefetcher without a backend.
+	fetchSingle func(*chainhash.Hash) (*blockWithPrevOuts, error)
+
+	// getHash resolves a height to the hash of the block currently at
+	// that height, or errors if the height isn't known (yet).
+	getHash func(int32) (*chainhash.Hash, error)
+
+	depth   int32
+	pending map[int32]prefetchedBlock
+}
+
+// newBlockPrefetcher wraps the given fetcher with a prefetch window of
+// prefetchDepth blocks, resolving upcoming heights through the given cache.
+func newBlockPrefetcher(fetcher *blockPrevOutFetcher,
+	h2hCache *heightToHashCache) *blockPrefetcher {
+
+	return &blockPrefetcher{
+		fetchSingle: fetcher.fetchBlock,
+		getHash:     h2hCache.getBlockHash,
+		depth:       prefetchDepth,
+		pending:     make(map[int32]prefetchedBlock),
+	}
+}
+
+// fetchBlock returns the block at the given height and hash, using a
+// previously prefetched result when possible, and schedules background
+// fetches for the heights following it.
+func (p *blockPrefetcher) fetchBlock(height int32,
+	hash *chainhash.Hash) (*blockWithPrevOuts, error) {
+
+	p.scheduleAhead(height)
+
+	entry, ok := p.pending[height]
+	if ok {
+		delete(p.pending, height)
+
+		res := <-entry.result
+
+		// Only use the prefetched result if it was fetched for the
+		// hash the caller expects; a reorg may have replaced the
+		// block since the fetch was scheduled. Stale and failed
+		// prefetches alike are simply retried through the direct
+		// fetch below.
+		if res.err == nil && entry.hash.IsEqual(hash) {
+			return res.block, nil
+		}
+	}
+
+	return p.fetchSingle(hash)
+}
+
+// scheduleAhead starts background fetches for the blocks following the given
+// height, until the prefetch window is full or a height can't be resolved to
+// a hash, which usually means we've caught up to the chain tip.
+func (p *blockPrefetcher) scheduleAhead(height int32) {
+	for h := height + 1; h <= height+p.depth; h++ {
+		if _, ok := p.pending[h]; ok {
+			continue
+		}
+
+		hash, err := p.getHash(h)
+		if err != nil {
+			return
+		}
+
+		entry := prefetchedBlock{
+			hash:   *hash,
+			result: make(chan prefetchResult, 1),
+		}
+		p.pending[h] = entry
+
+		go func() {
+			block, err := p.fetchSingle(hash)
+			entry.result <- prefetchResult{block: block, err: err}
+		}()
+	}
 }
 
 // requireREST probes the backend's REST API and returns an error if it isn't

--- a/block-prevouts.go
+++ b/block-prevouts.go
@@ -1,0 +1,454 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/rpcclient"
+	"github.com/btcsuite/btcd/wire/v2"
+)
+
+const (
+	// restProbePath is the REST endpoint used to detect whether the
+	// backend has its REST API (rest=1) enabled.
+	restProbePath = "/rest/chaininfo.json"
+
+	// restBlockPathPattern is the REST endpoint that serves a block in
+	// raw binary format.
+	restBlockPathPattern = "/rest/block/%s.bin"
+
+	// restSpentTxOutsPathPattern is the REST endpoint that serves the
+	// previous outputs spent by all transactions of a block (the block's
+	// undo data) in raw binary format. Available since bitcoind v30.0.
+	restSpentTxOutsPathPattern = "/rest/spenttxouts/%s.bin"
+
+	// restRequestTimeout is the timeout for a single REST request to the
+	// backend. Generous, since the backend only reads the block and undo
+	// data from disk, without any re-encoding.
+	restRequestTimeout = 30 * time.Second
+
+	// maxSpentTxOutsPerBlock is a sanity cap on the list counts parsed
+	// from a /rest/spenttxouts response, to avoid huge allocations on a
+	// corrupt length prefix. A block can't contain more transactions (or
+	// inputs) than its serialized size in bytes.
+	maxSpentTxOutsPerBlock = wire.MaxBlockPayload
+)
+
+// getBlockScriptPubKey is the subset of the scriptPubKey JSON object of the
+// getblock RPC response that we're interested in.
+type getBlockScriptPubKey struct {
+	Hex string `json:"hex"`
+}
+
+// getBlockPrevOut is the previous output data the getblock RPC includes for
+// every transaction input when invoked with verbosity level 3. The data is
+// served from the node's undo data, so it's available without a transaction
+// index, but only for unpruned blocks.
+type getBlockPrevOut struct {
+	// The field name is dictated by bitcoind's JSON-RPC format.
+	//
+	//nolint:tagliatelle
+	ScriptPubKey getBlockScriptPubKey `json:"scriptPubKey"`
+}
+
+// getBlockVin is the subset of a transaction input JSON object of the
+// getblock RPC response that we're interested in.
+type getBlockVin struct {
+	PrevOut *getBlockPrevOut `json:"prevout"`
+}
+
+// getBlockTx is the subset of a transaction JSON object of the getblock RPC
+// response that we're interested in.
+type getBlockTx struct {
+	Hex string        `json:"hex"`
+	Vin []getBlockVin `json:"vin"`
+}
+
+// getBlockResult is the subset of the getblock RPC response that we're
+// interested in.
+type getBlockResult struct {
+	Tx []getBlockTx `json:"tx"`
+}
+
+// blockWithPrevOuts bundles a block's transactions with the pkScripts of all
+// previous outputs spent by them.
+type blockWithPrevOuts struct {
+	// txs are the block's transactions in block order.
+	txs []*wire.MsgTx
+
+	// prevOutScripts maps each outpoint spent in the block to the
+	// pkScript of the output it references.
+	prevOutScripts map[wire.OutPoint][]byte
+}
+
+// fetchPrevOutScript returns the pkScript of the output referenced by the
+// given outpoint. It satisfies the sp.PrevOutFetcher signature, so it can be
+// passed directly to the Silent Payments tweak calculation.
+func (b *blockWithPrevOuts) fetchPrevOutScript(op wire.OutPoint) ([]byte,
+	error) {
+
+	pkScript, ok := b.prevOutScripts[op]
+	if !ok {
+		return nil, fmt.Errorf("no previous output script known for "+
+			"outpoint %v", op)
+	}
+
+	return pkScript, nil
+}
+
+// blockPrevOutFetcher fetches blocks together with the previous output
+// scripts of all inputs spent in them. It prefers the backend's binary REST
+// API (bitcoind v30.0 or later with rest=1), which serves both the block and
+// its undo data without any re-encoding and is orders of magnitude faster
+// than the getblock RPC at verbosity level 3, where the JSON rendering of
+// the block dominates the request time (see bitcoin/bitcoin#30495). If the
+// REST API isn't available, it falls back to the RPC.
+type blockPrevOutFetcher struct {
+	chain *rpcclient.Client
+
+	restURL    string
+	httpClient *http.Client
+
+	// probeOnce guards the one-time REST availability check, so the
+	// fetcher can be shared between producers.
+	probeOnce sync.Once
+	useREST   bool
+}
+
+// backendRESTURL returns the base URL of the backend's REST API, derived
+// from the RPC connection config, since bitcoind serves the REST API on its
+// RPC port.
+func backendRESTURL(chainCfg *rpcclient.ConnConfig) string {
+	protocol := "https"
+	if chainCfg.DisableTLS {
+		protocol = "http"
+	}
+
+	return fmt.Sprintf("%s://%s", protocol, chainCfg.Host)
+}
+
+// newBlockPrevOutFetcher creates a fetcher that talks to the same backend as
+// the given RPC client.
+func newBlockPrevOutFetcher(chain *rpcclient.Client,
+	chainCfg *rpcclient.ConnConfig) *blockPrevOutFetcher {
+
+	return &blockPrevOutFetcher{
+		chain:   chain,
+		restURL: backendRESTURL(chainCfg),
+		httpClient: &http.Client{
+			Timeout: restRequestTimeout,
+		},
+	}
+}
+
+// fetchBlock fetches the block with the given hash, along with the previous
+// output scripts of all inputs spent in it, using the fastest mechanism the
+// backend supports.
+func (f *blockPrevOutFetcher) fetchBlock(
+	hash *chainhash.Hash) (*blockWithPrevOuts, error) {
+
+	f.probeOnce.Do(f.probeREST)
+
+	if f.useREST {
+		return f.fetchBlockREST(hash)
+	}
+
+	return getBlockWithPrevOuts(f.chain, hash)
+}
+
+// probeREST checks whether the backend's REST API is enabled and records the
+// result. We only probe once: the RPC connection was already verified by the
+// time the first block is fetched, so an unreachable REST endpoint means the
+// API is disabled, not that the backend is down.
+func (f *blockPrevOutFetcher) probeREST() {
+	fallbackMsg := "falling back to the getblock RPC for fetching " +
+		"previous outputs; enable rest=1 on bitcoind v30.0 or later " +
+		"for significantly faster indexing"
+
+	resp, err := f.httpClient.Get(f.restURL + restProbePath)
+	if err != nil {
+		log.Infof("REST API not reachable at %s (%v), %s", f.restURL,
+			err, fallbackMsg)
+
+		return
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		log.Infof("REST API not enabled on backend (HTTP status %d "+
+			"on %s%s), %s", resp.StatusCode, f.restURL,
+			restProbePath, fallbackMsg)
+
+		return
+	}
+
+	log.Infof("Using the backend's REST API at %s to fetch blocks and "+
+		"spent outputs", f.restURL)
+	f.useREST = true
+}
+
+// restGet performs a GET request against the given REST path on the backend
+// and returns the raw response body.
+func (f *blockPrevOutFetcher) restGet(path string) ([]byte, error) {
+	url := f.restURL + path
+	resp, err := f.httpClient.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("error calling REST endpoint %s: %w",
+			url, err)
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response of REST "+
+			"endpoint %s: %w", url, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("REST endpoint %s returned HTTP "+
+			"status %d: %s", url, resp.StatusCode,
+			strings.TrimSpace(string(body)))
+	}
+
+	return body, nil
+}
+
+// fetchBlockREST fetches the block and its spent outputs through the
+// backend's binary REST API. The spent output lists returned by the
+// spenttxouts endpoint align positionally with the block's transactions and
+// their inputs, so no further lookups are needed to pair them up.
+func (f *blockPrevOutFetcher) fetchBlockREST(
+	hash *chainhash.Hash) (*blockWithPrevOuts, error) {
+
+	blockBytes, err := f.restGet(fmt.Sprintf(restBlockPathPattern, hash))
+	if err != nil {
+		return nil, fmt.Errorf("error fetching block %v: %w", hash,
+			err)
+	}
+
+	block := &wire.MsgBlock{}
+	if err := block.Deserialize(bytes.NewReader(blockBytes)); err != nil {
+		return nil, fmt.Errorf("error deserializing block %v: %w",
+			hash, err)
+	}
+
+	// A 404 here (with the block itself present) means the block's undo
+	// data is unavailable, which happens for pruned blocks.
+	spentBytes, err := f.restGet(
+		fmt.Sprintf(restSpentTxOutsPathPattern, hash),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching spent outputs of "+
+			"block %v: %w", hash, err)
+	}
+
+	spentTxOuts, err := parseSpentTxOuts(bytes.NewReader(spentBytes))
+	if err != nil {
+		return nil, fmt.Errorf("error parsing spent outputs of "+
+			"block %v: %w", hash, err)
+	}
+
+	if len(spentTxOuts) != len(block.Transactions) {
+		return nil, fmt.Errorf("tx count mismatch for block %v: %d "+
+			"spent output lists vs %d txs", hash,
+			len(spentTxOuts), len(block.Transactions))
+	}
+
+	result := &blockWithPrevOuts{
+		txs:            block.Transactions,
+		prevOutScripts: make(map[wire.OutPoint][]byte),
+	}
+	for txIndex, tx := range block.Transactions {
+		// The first list belongs to the coinbase transaction, which
+		// doesn't spend any previous outputs and is always empty.
+		if txIndex == 0 {
+			continue
+		}
+
+		spent := spentTxOuts[txIndex]
+		if len(spent) != len(tx.TxIn) {
+			return nil, fmt.Errorf("input count mismatch for tx "+
+				"%d in block %v: %d spent outputs vs %d "+
+				"inputs", txIndex, hash, len(spent),
+				len(tx.TxIn))
+		}
+
+		for vinIndex, txIn := range tx.TxIn {
+			result.prevOutScripts[txIn.PreviousOutPoint] =
+				spent[vinIndex].PkScript
+		}
+	}
+
+	return result, nil
+}
+
+// parseSpentTxOuts decodes the binary response of the /rest/spenttxouts
+// endpoint: a compact-size count of per-transaction lists (the first being
+// an always-empty placeholder for the coinbase transaction), each list
+// consisting of a compact-size count of wire-serialized outputs (8-byte
+// little-endian value followed by the compact-size-prefixed pkScript), one
+// per input of the spending transaction, in input order.
+func parseSpentTxOuts(r io.Reader) ([][]wire.TxOut, error) {
+	numTxs, err := wire.ReadVarInt(r, 0)
+	if err != nil {
+		return nil, fmt.Errorf("error reading tx count: %w", err)
+	}
+	if numTxs > maxSpentTxOutsPerBlock {
+		return nil, fmt.Errorf("tx count %d exceeds maximum %d",
+			numTxs, maxSpentTxOutsPerBlock)
+	}
+
+	spentTxOuts := make([][]wire.TxOut, numTxs)
+	for txIndex := range spentTxOuts {
+		numIns, err := wire.ReadVarInt(r, 0)
+		if err != nil {
+			return nil, fmt.Errorf("error reading input count of "+
+				"tx %d: %w", txIndex, err)
+		}
+		if numIns > maxSpentTxOutsPerBlock {
+			return nil, fmt.Errorf("input count %d of tx %d "+
+				"exceeds maximum %d", numIns, txIndex,
+				maxSpentTxOutsPerBlock)
+		}
+
+		if numIns == 0 {
+			continue
+		}
+
+		txOuts := make([]wire.TxOut, numIns)
+		for vinIndex := range txOuts {
+			var valueBytes [8]byte
+			if _, err := io.ReadFull(r, valueBytes[:]); err != nil {
+				return nil, fmt.Errorf("error reading value "+
+					"of spent output %d of tx %d: %w",
+					vinIndex, txIndex, err)
+			}
+
+			pkScript, err := wire.ReadVarBytes(
+				r, 0, wire.MaxMessagePayload, "pkScript",
+			)
+			if err != nil {
+				return nil, fmt.Errorf("error reading "+
+					"pkScript of spent output %d of tx "+
+					"%d: %w", vinIndex, txIndex, err)
+			}
+
+			txOuts[vinIndex] = wire.TxOut{
+				Value: int64(binary.LittleEndian.Uint64(
+					valueBytes[:],
+				)),
+				PkScript: pkScript,
+			}
+		}
+		spentTxOuts[txIndex] = txOuts
+	}
+
+	// The response must not contain any trailing data, otherwise we
+	// likely mis-parsed it.
+	if _, err := r.Read(make([]byte, 1)); err != io.EOF {
+		return nil, fmt.Errorf("unexpected trailing data after spent " +
+			"output lists")
+	}
+
+	return spentTxOuts, nil
+}
+
+// getBlockWithPrevOuts fetches the block with the given hash, along with the
+// previous output scripts of all inputs spent in it, using a single getblock
+// RPC call with verbosity level 3. That verbosity level is only understood by
+// bitcoind v25.0 or later; older versions silently fall back to verbosity
+// level 2, which we detect through the missing prevout data.
+func getBlockWithPrevOuts(chain *rpcclient.Client,
+	hash *chainhash.Hash) (*blockWithPrevOuts, error) {
+
+	hashParam, err := json.Marshal(hash.String())
+	if err != nil {
+		return nil, err
+	}
+	verbosityParam := json.RawMessage("3")
+
+	rawResult, err := chain.RawRequest(
+		"getblock", []json.RawMessage{hashParam, verbosityParam},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching block %v with "+
+			"getblock verbosity 3: %w", hash, err)
+	}
+
+	var result getBlockResult
+	if err := json.Unmarshal(rawResult, &result); err != nil {
+		return nil, fmt.Errorf("error decoding getblock response "+
+			"for block %v: %w", hash, err)
+	}
+
+	block := &blockWithPrevOuts{
+		txs:            make([]*wire.MsgTx, 0, len(result.Tx)),
+		prevOutScripts: make(map[wire.OutPoint][]byte),
+	}
+	for txIndex, rpcTx := range result.Tx {
+		// We decode the hex on the fly while deserializing, to avoid
+		// allocating an intermediate buffer for the raw transaction.
+		txReader := hex.NewDecoder(strings.NewReader(rpcTx.Hex))
+
+		tx := &wire.MsgTx{}
+		if err := tx.Deserialize(txReader); err != nil {
+			return nil, fmt.Errorf("error deserializing tx %d "+
+				"in block %v: %w", txIndex, hash, err)
+		}
+		block.txs = append(block.txs, tx)
+
+		// The coinbase transaction doesn't spend any previous
+		// outputs, so there is no prevout data to collect for it.
+		if blockchain.IsCoinBaseTx(tx) {
+			continue
+		}
+
+		if len(rpcTx.Vin) != len(tx.TxIn) {
+			return nil, fmt.Errorf("input count mismatch for tx "+
+				"%d in block %v: %d vs %d", txIndex, hash,
+				len(rpcTx.Vin), len(tx.TxIn))
+		}
+
+		for vinIndex, vin := range rpcTx.Vin {
+			if vin.PrevOut == nil {
+				return nil, fmt.Errorf("missing prevout data "+
+					"for input %d of tx %d in block %v; "+
+					"fetching previous outputs requires "+
+					"bitcoind v25.0 or later and an "+
+					"unpruned block", vinIndex, txIndex,
+					hash)
+			}
+
+			pkScript, err := hex.DecodeString(
+				vin.PrevOut.ScriptPubKey.Hex,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("error decoding "+
+					"prevout script of input %d of tx %d "+
+					"in block %v: %w", vinIndex, txIndex,
+					hash, err)
+			}
+
+			op := tx.TxIn[vinIndex].PreviousOutPoint
+			block.prevOutScripts[op] = pkScript
+		}
+	}
+
+	return block, nil
+}

--- a/block-prevouts_test.go
+++ b/block-prevouts_test.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseSpentTxOuts checks that the binary format of the /rest/spenttxouts
+// endpoint is parsed correctly and that truncated or oversized responses are
+// rejected.
+func TestParseSpentTxOuts(t *testing.T) {
+	var buf bytes.Buffer
+
+	writeSpentOut := func(value int64, pkScript []byte) {
+		var valueBytes [8]byte
+		binary.LittleEndian.PutUint64(valueBytes[:], uint64(value))
+		_, err := buf.Write(valueBytes[:])
+		require.NoError(t, err)
+		require.NoError(t, wire.WriteVarBytes(&buf, 0, pkScript))
+	}
+
+	// A block with three transactions: the always-empty coinbase
+	// placeholder, a transaction spending two outputs and one spending a
+	// single output.
+	script1 := []byte{0x51}
+	script2 := bytes.Repeat([]byte{0x02}, 22)
+	script3 := bytes.Repeat([]byte{0x03}, 34)
+
+	require.NoError(t, wire.WriteVarInt(&buf, 0, 3))
+	require.NoError(t, wire.WriteVarInt(&buf, 0, 0))
+	require.NoError(t, wire.WriteVarInt(&buf, 0, 2))
+	writeSpentOut(1_000, script1)
+	writeSpentOut(2_000, script2)
+	require.NoError(t, wire.WriteVarInt(&buf, 0, 1))
+	writeSpentOut(3_000, script3)
+
+	parsed, err := parseSpentTxOuts(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	require.Equal(t, [][]wire.TxOut{
+		nil,
+		{
+			{Value: 1_000, PkScript: script1},
+			{Value: 2_000, PkScript: script2},
+		},
+		{
+			{Value: 3_000, PkScript: script3},
+		},
+	}, parsed)
+
+	// Trailing data must be rejected.
+	_, err = parseSpentTxOuts(
+		bytes.NewReader(append(buf.Bytes(), 0x00)),
+	)
+	require.ErrorContains(t, err, "trailing data")
+
+	// Truncated data must be rejected.
+	_, err = parseSpentTxOuts(
+		bytes.NewReader(buf.Bytes()[:buf.Len()-1]),
+	)
+	require.Error(t, err)
+
+	// An absurdly high tx count must be rejected before any allocation.
+	var oversized bytes.Buffer
+	require.NoError(
+		t, wire.WriteVarInt(&oversized, 0, maxSpentTxOutsPerBlock+1),
+	)
+	_, err = parseSpentTxOuts(bytes.NewReader(oversized.Bytes()))
+	require.ErrorContains(t, err, "exceeds maximum")
+}
+
+// TestBlockPrevOutFetcher checks that the REST-based fast path returns the
+// same result as the getblock verbosity 3 RPC, and that the fetcher falls
+// back to the RPC when the backend's REST API isn't reachable.
+func TestBlockPrevOutFetcher(t *testing.T) {
+	miner, backend, backendCfg, _ := setupBackend(t, unitTestDir)
+
+	// Create a transaction spending miner outputs, so the next block
+	// contains a non-coinbase transaction with previous output data.
+	pkScript := append(
+		[]byte{0x00, 0x14}, bytes.Repeat([]byte{0x02}, 20)...,
+	)
+	miner.SendOutput(&wire.TxOut{
+		Value:    100_000,
+		PkScript: pkScript,
+	}, 2)
+
+	minedBlocks := miner.MineBlocksAndAssertNumTxes(1, 1)
+	waitBackendSync(t, backend, miner)
+	blockHash := minedBlocks[0].BlockHash()
+
+	// The RPC path serves as the reference result.
+	rpcBlock, err := getBlockWithPrevOuts(backend, &blockHash)
+	require.NoError(t, err)
+	require.NotEmpty(t, rpcBlock.prevOutScripts)
+
+	requireSameBlock := func(t *testing.T, actual *blockWithPrevOuts) {
+		t.Helper()
+
+		require.Len(t, actual.txs, len(rpcBlock.txs))
+		for idx, tx := range rpcBlock.txs {
+			require.Equal(
+				t, tx.TxHash(), actual.txs[idx].TxHash(),
+			)
+		}
+		require.Equal(
+			t, rpcBlock.prevOutScripts, actual.prevOutScripts,
+		)
+	}
+
+	// The test harness starts bitcoind with -rest, so the fetcher must
+	// pick the REST fast path.
+	t.Run("REST", func(t *testing.T) {
+		fetcher := newBlockPrevOutFetcher(backend, &backendCfg)
+		block, err := fetcher.fetchBlock(&blockHash)
+		require.NoError(t, err)
+		require.True(t, fetcher.useREST)
+
+		requireSameBlock(t, block)
+	})
+
+	// With an unreachable REST endpoint, the fetcher must fall back to
+	// the getblock RPC and still produce the same result.
+	t.Run("RPC fallback", func(t *testing.T) {
+		cfgCopy := backendCfg
+		cfgCopy.Host = "127.0.0.1:1"
+		fetcher := newBlockPrevOutFetcher(backend, &cfgCopy)
+		block, err := fetcher.fetchBlock(&blockHash)
+		require.NoError(t, err)
+		require.False(t, fetcher.useREST)
+
+		requireSameBlock(t, block)
+	})
+}
+
+// TestGetBlockWithPrevOuts checks that fetching a block through the getblock
+// RPC with verbosity level 3 returns the same transactions as the binary
+// getblock RPC, and that the previous output scripts collected from the undo
+// data match the outputs of the referenced transactions.
+func TestGetBlockWithPrevOuts(t *testing.T) {
+	miner, backend, _, _ := setupBackend(t, unitTestDir)
+
+	// Create a transaction spending miner outputs, so the next block
+	// contains a non-coinbase transaction with previous output data.
+	pkScript := append(
+		[]byte{0x00, 0x14}, bytes.Repeat([]byte{0x01}, 20)...,
+	)
+	miner.SendOutput(&wire.TxOut{
+		Value:    100_000,
+		PkScript: pkScript,
+	}, 2)
+
+	minedBlocks := miner.MineBlocksAndAssertNumTxes(1, 1)
+	waitBackendSync(t, backend, miner)
+
+	blockHash := minedBlocks[0].BlockHash()
+	block, err := getBlockWithPrevOuts(backend, &blockHash)
+	require.NoError(t, err)
+
+	// The result must contain the coinbase plus the transaction we just
+	// created, in the same order as the binary getblock RPC returns them.
+	rawBlock, err := backend.GetBlock(&blockHash)
+	require.NoError(t, err)
+	require.Len(t, block.txs, 2)
+	require.Len(t, block.txs, len(rawBlock.Transactions))
+	for idx, tx := range block.txs {
+		require.Equal(
+			t, rawBlock.Transactions[idx].TxHash(), tx.TxHash(),
+		)
+	}
+
+	// The coinbase doesn't spend any previous outputs, so it must not
+	// contribute an entry to the prevout map.
+	coinbase := block.txs[0]
+	require.True(t, blockchain.IsCoinBaseTx(coinbase))
+	_, err = block.fetchPrevOutScript(coinbase.TxIn[0].PreviousOutPoint)
+	require.ErrorContains(t, err, "no previous output script")
+
+	// Every input of the non-coinbase transaction must have its previous
+	// output script recorded, matching the output of the transaction it
+	// references.
+	for _, txIn := range block.txs[1].TxIn {
+		op := txIn.PreviousOutPoint
+
+		prevOutScript, err := block.fetchPrevOutScript(op)
+		require.NoError(t, err)
+
+		prevTx, err := backend.GetRawTransaction(&op.Hash)
+		require.NoError(t, err)
+		require.Equal(
+			t, prevTx.MsgTx().TxOut[op.Index].PkScript,
+			prevOutScript,
+		)
+	}
+}

--- a/block-prevouts_test.go
+++ b/block-prevouts_test.go
@@ -3,9 +3,12 @@ package main
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/stretchr/testify/require"
 )
@@ -140,6 +143,172 @@ func TestBlockPrevOutFetcher(t *testing.T) {
 
 		requireSameBlock(t, block)
 	})
+}
+
+// prefetchTestHarness is a blockPrefetcher hooked up to fake fetch and hash
+// resolution functions, recording every fetch so tests can assert how often
+// and for which hashes the underlying fetcher was invoked.
+type prefetchTestHarness struct {
+	sync.Mutex
+
+	prefetcher *blockPrefetcher
+
+	tip        int32
+	hashSuffix byte
+	fetches    map[chainhash.Hash]int
+	failNext   map[chainhash.Hash]bool
+}
+
+// hashAt derives the deterministic fake hash of the given height on the
+// harness' current chain. Bumping hashSuffix simulates a reorg: every
+// height resolves to a new hash.
+func (h *prefetchTestHarness) hashAt(height int32) *chainhash.Hash {
+	var hash chainhash.Hash
+	binary.LittleEndian.PutUint32(hash[:4], uint32(height))
+	hash[4] = h.hashSuffix
+
+	return &hash
+}
+
+func newPrefetchTestHarness(tip int32, depth int32) *prefetchTestHarness {
+	h := &prefetchTestHarness{
+		tip:      tip,
+		fetches:  make(map[chainhash.Hash]int),
+		failNext: make(map[chainhash.Hash]bool),
+	}
+
+	h.prefetcher = &blockPrefetcher{
+		fetchSingle: func(hash *chainhash.Hash) (*blockWithPrevOuts,
+			error) {
+
+			h.Lock()
+			defer h.Unlock()
+
+			h.fetches[*hash]++
+			if h.failNext[*hash] {
+				delete(h.failNext, *hash)
+				return nil, fmt.Errorf("transient failure")
+			}
+
+			// Embed the fetched hash in the result, so the test
+			// can verify which block a fetch produced.
+			return &blockWithPrevOuts{
+				prevOutScripts: map[wire.OutPoint][]byte{
+					{Hash: *hash}: hash[:],
+				},
+			}, nil
+		},
+		getHash: func(height int32) (*chainhash.Hash, error) {
+			h.Lock()
+			defer h.Unlock()
+
+			if height > h.tip {
+				return nil, fmt.Errorf("height %d out of "+
+					"range", height)
+			}
+
+			return h.hashAt(height), nil
+		},
+		depth:   depth,
+		pending: make(map[int32]prefetchedBlock),
+	}
+
+	return h
+}
+
+// fetchAndCheck fetches the block at the given height through the prefetcher
+// and asserts it corresponds to the current chain's hash at that height.
+func (h *prefetchTestHarness) fetchAndCheck(t *testing.T, height int32) {
+	t.Helper()
+
+	h.Lock()
+	hash := h.hashAt(height)
+	h.Unlock()
+
+	block, err := h.prefetcher.fetchBlock(height, hash)
+	require.NoError(t, err)
+	require.Contains(t, block.prevOutScripts, wire.OutPoint{Hash: *hash})
+}
+
+// numFetches returns how often the underlying fetcher was invoked in total.
+func (h *prefetchTestHarness) numFetches() int {
+	h.Lock()
+	defer h.Unlock()
+
+	total := 0
+	for _, count := range h.fetches {
+		total += count
+	}
+
+	return total
+}
+
+// TestBlockPrefetcherSequential checks that sequential consumption returns
+// the correct block for every height, fetches every block exactly once and
+// never exceeds the configured prefetch depth.
+func TestBlockPrefetcherSequential(t *testing.T) {
+	const (
+		tip   = 20
+		depth = 4
+	)
+	h := newPrefetchTestHarness(tip, depth)
+
+	for height := range int32(tip + 1) {
+		h.fetchAndCheck(t, height)
+
+		require.LessOrEqual(t, len(h.prefetcher.pending), depth)
+	}
+
+	// Every block was fetched exactly once: heights consumed directly
+	// plus prefetched ones, no duplicates, nothing beyond the tip.
+	require.Equal(t, tip+1, h.numFetches())
+	require.Empty(t, h.prefetcher.pending)
+}
+
+// TestBlockPrefetcherReorg checks that prefetched blocks that were scheduled
+// before a reorg are discarded and re-fetched with the post-reorg hash.
+func TestBlockPrefetcherReorg(t *testing.T) {
+	h := newPrefetchTestHarness(20, 4)
+
+	// Consume a few blocks, so the window [6, 9] is prefetched with
+	// pre-reorg hashes.
+	for height := range int32(6) {
+		h.fetchAndCheck(t, height)
+	}
+
+	// Simulate a reorg back to height 3: every height now resolves to a
+	// different hash.
+	h.Lock()
+	h.hashSuffix = 0xff
+	h.Unlock()
+
+	// Continuing from height 4 must transparently discard the stale
+	// prefetches and return the blocks of the new chain.
+	for height := int32(4); height <= 10; height++ {
+		h.fetchAndCheck(t, height)
+	}
+}
+
+// TestBlockPrefetcherFailedPrefetch checks that a failed background fetch is
+// transparently retried when its height is consumed.
+func TestBlockPrefetcherFailedPrefetch(t *testing.T) {
+	h := newPrefetchTestHarness(20, 4)
+
+	// Make the background fetch of height 2 fail once. It is scheduled
+	// by the first fetchBlock call, before height 2 is consumed.
+	h.Lock()
+	h.failNext[*h.hashAt(2)] = true
+	h.Unlock()
+
+	for height := range int32(6) {
+		h.fetchAndCheck(t, height)
+	}
+
+	h.Lock()
+	defer h.Unlock()
+	require.Equal(t, 2, h.fetches[*h.hashAt(2)],
+		"height 2 must have been fetched again after the failed "+
+			"prefetch")
 }
 
 // TestVerifySPTweakBackendVersion pins the minimum backend version required

--- a/block-prevouts_test.go
+++ b/block-prevouts_test.go
@@ -113,9 +113,11 @@ func TestBlockPrevOutFetcher(t *testing.T) {
 	}
 
 	// The test harness starts bitcoind with -rest, so the fetcher must
-	// pick the REST fast path.
+	// pick the REST fast path and the REST requirement check must pass.
 	t.Run("REST", func(t *testing.T) {
 		fetcher := newBlockPrevOutFetcher(backend, &backendCfg)
+		require.NoError(t, fetcher.requireREST())
+
 		block, err := fetcher.fetchBlock(&blockHash)
 		require.NoError(t, err)
 		require.True(t, fetcher.useREST)
@@ -123,18 +125,30 @@ func TestBlockPrevOutFetcher(t *testing.T) {
 		requireSameBlock(t, block)
 	})
 
-	// With an unreachable REST endpoint, the fetcher must fall back to
-	// the getblock RPC and still produce the same result.
+	// With an unreachable REST endpoint, the REST requirement check must
+	// fail with an actionable error, while the fetcher itself falls back
+	// to the getblock RPC and still produces the same result.
 	t.Run("RPC fallback", func(t *testing.T) {
 		cfgCopy := backendCfg
 		cfgCopy.Host = "127.0.0.1:1"
 		fetcher := newBlockPrevOutFetcher(backend, &cfgCopy)
+		require.ErrorContains(t, fetcher.requireREST(), "rest=1")
+
 		block, err := fetcher.fetchBlock(&blockHash)
 		require.NoError(t, err)
 		require.False(t, fetcher.useREST)
 
 		requireSameBlock(t, block)
 	})
+}
+
+// TestVerifySPTweakBackendVersion pins the minimum backend version required
+// for indexing SP tweak data.
+func TestVerifySPTweakBackendVersion(t *testing.T) {
+	require.Error(t, verifySPTweakBackendVersion(250_000))
+	require.Error(t, verifySPTweakBackendVersion(299_900))
+	require.NoError(t, verifySPTweakBackendVersion(300_000))
+	require.NoError(t, verifySPTweakBackendVersion(310_100))
 }
 
 // TestGetBlockWithPrevOuts checks that fetching a block through the getblock

--- a/file-producer.go
+++ b/file-producer.go
@@ -184,7 +184,8 @@ func (p *producerBase) updateFiles(numBlocks int32) error {
 }
 
 // updateCacheAndFiles ingests every block in [startBlock, endBlock] via the
-// producer's ingest hook, then seals any files that are now reorg-safe.
+// producer's ingest hook, sealing any files that become reorg-safe along the
+// way.
 func (p *producerBase) updateCacheAndFiles(startBlock, endBlock int32) error {
 	for i := startBlock; i <= endBlock; i++ {
 		select {
@@ -198,8 +199,17 @@ func (p *producerBase) updateCacheAndFiles(startBlock, endBlock int32) error {
 		}
 
 		p.currentHeight.Store(i)
+
+		// Seal after every block instead of once at the end of the
+		// range, so a long initial catch-up persists its progress
+		// incrementally and doesn't accumulate the entire range in
+		// memory. When there's nothing to seal, this returns after a
+		// cheap boundary check.
+		if err := p.sealReadyFiles(); err != nil {
+			return err
+		}
 	}
-	return p.sealReadyFiles()
+	return nil
 }
 
 // sealReadyFiles writes any file whose last height has fallen at least

--- a/file-producer_test.go
+++ b/file-producer_test.go
@@ -184,6 +184,46 @@ func TestSealReadyFiles_SecondFileWriteErrorPreservesFirstAdvance(t *testing.T) 
 		"lastSealedHeight should reflect the one successful seal")
 }
 
+func TestUpdateCacheAndFiles_SealsDuringCatchUp(t *testing.T) {
+	// Regression test: a long catch-up must seal each file as soon as its
+	// range has dropped reorg-safe-depth below the ingest position, not
+	// in a single burst once the entire range has been ingested. The
+	// latter would hold the whole range in memory and lose all catch-up
+	// progress on restart, since resumption starts after the last file
+	// on disk.
+	p, _ := newTestProducer(100, 6)
+
+	// Record the ingest position at which every seal happens.
+	type sealEvent struct {
+		fileStart int32
+		fileEnd   int32
+		atHeight  int32
+	}
+	var seals []sealEvent
+	p.hooks.ingest = func(int32) error {
+		return nil
+	}
+	p.hooks.writeSealedFile = func(s, e int32) error {
+		seals = append(seals, sealEvent{
+			fileStart: s,
+			fileEnd:   e,
+			atHeight:  p.currentHeight.Load(),
+		})
+		return nil
+	}
+
+	require.NoError(t, p.updateCacheAndFiles(0, 305))
+
+	// Every file must have been sealed at the earliest height at which
+	// its last block became reorg-safe.
+	require.Equal(t, []sealEvent{
+		{fileStart: 0, fileEnd: 99, atHeight: 105},
+		{fileStart: 100, fileEnd: 199, atHeight: 205},
+		{fileStart: 200, fileEnd: 299, atHeight: 305},
+	}, seals)
+	require.EqualValues(t, 299, p.lastSealedHeight.Load())
+}
+
 func TestRollback_PrunesRangeAndInvalidatesCache(t *testing.T) {
 	// Build a producer with a small populated h2hCache and assert that
 	// rollback (a) calls pruneLocked with the right inclusive range,

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/btcsuite/btcwallet/walletdb v1.6.0
 	github.com/gorilla/mux v1.8.0
 	github.com/lightninglabs/neutrino v0.18.0
-	github.com/lightninglabs/neutrino/cache v1.1.4
 	github.com/lightningnetwork/lnd v0.20.0-beta.rc4.0.20260520222613-2a4aab892a8a
 	github.com/lightningnetwork/lnd/fn/v2 v2.0.9
 	github.com/spf13/cobra v1.10.1
@@ -210,6 +209,7 @@ require (
 	github.com/leonklingele/grouper v1.1.2 // indirect
 	github.com/lib/pq v1.10.9 // indirect
 	github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf // indirect
+	github.com/lightninglabs/neutrino/cache v1.1.4 // indirect
 	github.com/lightningnetwork/lightning-onion v1.4.0 // indirect
 	github.com/lightningnetwork/lnd/actor v0.0.6 // indirect
 	github.com/lightningnetwork/lnd/cert v1.2.2 // indirect

--- a/handlers.go
+++ b/handlers.go
@@ -709,12 +709,8 @@ func (s *server) blockSpentTxOutsRequestHandler(w http.ResponseWriter,
 		format = queryFormat
 	}
 
-	protocol := "https"
-	if s.chainCfg.DisableTLS {
-		protocol = "http"
-	}
-	url := fmt.Sprintf("%s://%s/rest/spenttxouts/%s.%s", protocol,
-		s.chainCfg.Host, blockHash.String(), format)
+	url := fmt.Sprintf("%s/rest/spenttxouts/%s.%s",
+		backendRESTURL(s.chainCfg), blockHash.String(), format)
 
 	client := &http.Client{
 		Timeout: backendRequestTimeout,
@@ -845,12 +841,9 @@ func (s *server) utxoRequestHandler(w http.ResponseWriter, r *http.Request) {
 		format = queryFormat
 	}
 
-	protocol := "https"
-	if s.chainCfg.DisableTLS {
-		protocol = "http"
-	}
-	url := fmt.Sprintf("%s://%s/rest/getutxos/%s%s-%d.%s", protocol,
-		s.chainCfg.Host, mempool, txHash.String(), vOut, format)
+	url := fmt.Sprintf("%s/rest/getutxos/%s%s-%d.%s",
+		backendRESTURL(s.chainCfg), mempool, txHash.String(), vOut,
+		format)
 
 	client := &http.Client{
 		Timeout: backendRequestTimeout,

--- a/main.go
+++ b/main.go
@@ -152,8 +152,7 @@ func main() {
 				cc.listenAddr, cc.bitcoindConfig, chainParams,
 				cc.reOrgSafeDepth, headersPerFile,
 				filtersPerFile, spTweaksPerFile,
-				cc.prevOutCacheSizeMiB, cc.readTimeout,
-				cc.writeTimeout,
+				cc.readTimeout, cc.writeTimeout,
 			)
 			err := server.start()
 			if err != nil {
@@ -212,15 +211,19 @@ func main() {
 			"Payments tweak data that allows light clients to "+
 			"scan the chain for inbound SP more efficiently; "+
 			"this requires every block since the activation of "+
-			"Taproot to be indexed which may take a while",
+			"Taproot to be indexed which may take a while; "+
+			"requires bitcoind v25.0 or later, and setting "+
+			"rest=1 on bitcoind v30.0 or later speeds up the "+
+			"indexing significantly",
 	)
 	cc.cmd.PersistentFlags().Uint16Var(
-		&cc.prevOutCacheSizeMiB, "prev-out-cache-size-mib",
-		DefaultPrevOutCacheMiBytes, "The size of the in-memory "+
-			"previous output cache in MiB; this cache is only "+
-			"used if --index-sp-tweak-data is enabled and stores "+
-			"previous outputs of transactions to speed up "+
-			"indexing of SP tweak data",
+		&cc.prevOutCacheSizeMiB, "prev-out-cache-size-mib", 1024,
+		"Deprecated, has no effect",
+	)
+	_ = cc.cmd.PersistentFlags().MarkDeprecated(
+		"prev-out-cache-size-mib", "previous outputs are now fetched "+
+			"from bitcoind directly through the getblock RPC, so "+
+			"no cache is needed anymore",
 	)
 	cc.cmd.PersistentFlags().StringVar(
 		&cc.baseDir, "base-dir", "", "The base directory "+

--- a/main.go
+++ b/main.go
@@ -212,9 +212,8 @@ func main() {
 			"scan the chain for inbound SP more efficiently; "+
 			"this requires every block since the activation of "+
 			"Taproot to be indexed which may take a while; "+
-			"requires bitcoind v25.0 or later, and setting "+
-			"rest=1 on bitcoind v30.0 or later speeds up the "+
-			"indexing significantly",
+			"requires bitcoind v30.0 or later with the REST API "+
+			"enabled (rest=1)",
 	)
 	cc.cmd.PersistentFlags().Uint16Var(
 		&cc.prevOutCacheSizeMiB, "prev-out-cache-size-mib", 1024,

--- a/main_test.go
+++ b/main_test.go
@@ -1000,8 +1000,7 @@ func TestBlockDN(t *testing.T) {
 		false, true, dataDir, listenAddr, &backendCfg,
 		unittest.NetParams, 6, DefaultRegtestHeadersPerFile,
 		DefaultRegtestFiltersPerFile, DefaultRegtestSPTweaksPerFile,
-		DefaultPrevOutCacheMiBytes, defaultReadTimeout,
-		defaultWriteTimeout,
+		defaultReadTimeout, defaultWriteTimeout,
 	)
 	ctx := &testContext{
 		miner:   miner,

--- a/reorg_safe_test.go
+++ b/reorg_safe_test.go
@@ -120,7 +120,7 @@ func startReorgTestServer(t *testing.T,
 		false, true, dataDir, listenAddr, &backendCfg,
 		unittest.NetParams, params.reOrgSafeDepth,
 		params.headersPerFile, params.filtersPerFile,
-		params.spTweaksPerFile, DefaultPrevOutCacheMiBytes,
+		params.spTweaksPerFile,
 		defaultReadTimeout, defaultWriteTimeout,
 	)
 	ctx := &testContext{

--- a/server.go
+++ b/server.go
@@ -50,10 +50,9 @@ type server struct {
 	router           *mux.Router
 	httpServer       *http.Server
 
-	headersPerFile      int32
-	filtersPerFile      int32
-	spTweaksPerFile     int32
-	spTweakCacheSizeMiB uint16
+	headersPerFile  int32
+	filtersPerFile  int32
+	spTweaksPerFile int32
 
 	h2hCache     *heightToHashCache
 	headerFiles  *headerFiles
@@ -68,7 +67,7 @@ type server struct {
 func newServer(lightMode, indexSPTweakData bool, baseDir, listenAddr string,
 	chainCfg *rpcclient.ConnConfig, chainParams *chaincfg.Params,
 	reOrgSafeDepth uint32, headersPerFile, filtersPerFile,
-	spTweaksPerFile int32, spTweakCacheSizeMiB uint16, readTimeout,
+	spTweaksPerFile int32, readTimeout,
 	writeTimeout time.Duration) *server {
 
 	// A zero timeout would disable the protection entirely; fall back to
@@ -91,10 +90,9 @@ func newServer(lightMode, indexSPTweakData bool, baseDir, listenAddr string,
 		readTimeout:      readTimeout,
 		writeTimeout:     writeTimeout,
 
-		headersPerFile:      headersPerFile,
-		filtersPerFile:      filtersPerFile,
-		spTweaksPerFile:     spTweaksPerFile,
-		spTweakCacheSizeMiB: spTweakCacheSizeMiB,
+		headersPerFile:  headersPerFile,
+		filtersPerFile:  filtersPerFile,
+		spTweaksPerFile: spTweaksPerFile,
 
 		errs: fn.NewConcurrentQueue[error](2),
 		quit: make(chan struct{}),
@@ -227,7 +225,8 @@ func (s *server) start() error {
 
 	s.spTweakFiles = newSPTweakFiles(
 		s.spTweaksPerFile, int32(s.reOrgSafeDepth), s.chain, s.quit,
-		s.baseDir, s.chainParams, s.h2hCache, s.spTweakCacheSizeMiB,
+		s.baseDir, s.chainParams, s.h2hCache,
+		newBlockPrevOutFetcher(s.chain, s.chainCfg),
 	)
 
 	s.wg.Add(1)

--- a/server.go
+++ b/server.go
@@ -103,12 +103,39 @@ func newServer(lightMode, indexSPTweakData bool, baseDir, listenAddr string,
 	return s
 }
 
+// checkSPTweakBackend verifies that the connected backend meets the
+// requirements for indexing SP tweak data: bitcoind v30.0 or later with the
+// REST API enabled.
+func (s *server) checkSPTweakBackend(fetcher *blockPrevOutFetcher) error {
+	info, err := s.chain.GetNetworkInfo()
+	if err != nil {
+		return fmt.Errorf("error querying backend version: %w", err)
+	}
+
+	if err := verifySPTweakBackendVersion(info.Version); err != nil {
+		return err
+	}
+
+	return fetcher.requireREST()
+}
+
 func (s *server) start() error {
 	client, err := rpcclient.New(s.chainCfg, nil)
 	if err != nil {
 		return fmt.Errorf("error connecting to bitcoind: %w", err)
 	}
 	s.chain = client
+
+	// Indexing SP tweak data needs the backend's undo data, which is only
+	// served through the REST API of bitcoind v30.0 or later. We verify
+	// both requirements up front, so a misconfigured backend fails the
+	// startup instead of surfacing an error mid-catch-up.
+	blockFetcher := newBlockPrevOutFetcher(s.chain, s.chainCfg)
+	if s.indexSPTweakData && !s.lightMode {
+		if err := s.checkSPTweakBackend(blockFetcher); err != nil {
+			return err
+		}
+	}
 
 	s.h2hCache = newH2HCache(client)
 
@@ -225,8 +252,7 @@ func (s *server) start() error {
 
 	s.spTweakFiles = newSPTweakFiles(
 		s.spTweaksPerFile, int32(s.reOrgSafeDepth), s.chain, s.quit,
-		s.baseDir, s.chainParams, s.h2hCache,
-		newBlockPrevOutFetcher(s.chain, s.chainCfg),
+		s.baseDir, s.chainParams, s.h2hCache, blockFetcher,
 	)
 
 	s.wg.Add(1)

--- a/silent-payments-files.go
+++ b/silent-payments-files.go
@@ -64,9 +64,13 @@ type spTweakFiles struct {
 	blockFetcher *blockPrefetcher
 
 	// numBlocksIndexed counts the blocks indexed since the last stats
-	// log line, which we emit whenever a file is sealed. Only accessed
-	// from the producer goroutine, so no locking is required.
+	// log line, which we emit whenever a file is sealed. Together with
+	// the fetch/compute split below it shows where the indexing time
+	// goes. Only accessed from the producer goroutine, so no locking is
+	// required.
 	numBlocksIndexed int32
+	statsFetchWait   time.Duration
+	statsCompute     time.Duration
 	statsLastReset   time.Time
 
 	// taprootStartHeight is the activation height for the current
@@ -158,16 +162,20 @@ func (s *spTweakFiles) ingest(height int32) error {
 		return nil
 	}
 
+	fetchStart := time.Now()
 	block, err := s.blockFetcher.fetchBlock(height, hash)
 	if err != nil {
 		return fmt.Errorf("error getting block for SP tweak data: %w",
 			err)
 	}
 	s.numBlocksIndexed++
+	s.statsFetchWait += time.Since(fetchStart)
 
+	computeStart := time.Now()
 	if err := s.indexBlockSPTweakData(height, block); err != nil {
 		return fmt.Errorf("error indexing SP tweak data: %w", err)
 	}
+	s.statsCompute += time.Since(computeStart)
 
 	return nil
 }
@@ -183,13 +191,18 @@ func (s *spTweakFiles) writeSealedFile(fileStart, fileEnd int32) error {
 
 	// Log the indexing throughput now that we've written another batch of
 	// tweak data to disk, so the initial catch-up progress can be
-	// observed.
+	// observed. The fetch/compute split shows whether the time goes into
+	// waiting for the backend or into the tweak computation itself.
 	since := time.Since(s.statsLastReset).Seconds()
 	log.Debugf("SP tweak data: indexed %d blocks in %.1fs (%.2f blocks "+
-		"per second)", s.numBlocksIndexed, since,
-		float64(s.numBlocksIndexed)/since)
+		"per second; %.1fs waiting on block fetch, %.1fs computing "+
+		"tweaks)", s.numBlocksIndexed, since,
+		float64(s.numBlocksIndexed)/since,
+		s.statsFetchWait.Seconds(), s.statsCompute.Seconds())
 
 	s.numBlocksIndexed = 0
+	s.statsFetchWait = 0
+	s.statsCompute = 0
 	s.statsLastReset = time.Now()
 
 	return nil

--- a/silent-payments-files.go
+++ b/silent-payments-files.go
@@ -18,24 +18,13 @@ import (
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/rpcclient"
 	sp "github.com/btcsuite/btcd/silentpayments"
-	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
-	"github.com/lightninglabs/neutrino/cache/lru"
 )
 
 const (
 	DefaultSPTweaksPerFile = 2_000
 
 	DefaultRegtestSPTweaksPerFile = 2_000
-
-	// DefaultPrevOutCacheMiBytes is the default size we allow the Taproot
-	// previous output script cache to grow to. This is a hard limit as
-	// we're using an LRU cache, so once we reach this limit, we will evict
-	// the least recently used entry from the cache for each new entry we
-	// add. We set this to 1GiB by default, to make sure systems with
-	// limited resources can still use the SP tweak data indexing without
-	// running out of memory.
-	DefaultPrevOutCacheMiBytes = 1024
 
 	SPTweakFileDir = "silentpayments"
 
@@ -59,137 +48,6 @@ var (
 	)
 )
 
-// byteCacheEntry is a simple wrapper around a byte slice that implements the
-// cache.Value interface, which allows us to store previous output scripts in
-// the LRU cache.
-type byteCacheEntry []byte
-
-// Size determines how big this entry is in the cache. We need to account for
-// the size of the key (the outpoint) as well, which is 36 bytes (32 for the
-// txid and 4 for the index).
-// nolint:unparam
-func (b byteCacheEntry) Size() (uint64, error) {
-	return uint64(len(b)) + 36, nil
-}
-
-type prevOutCache struct {
-	numBlock   int32
-	numTx      int32
-	numTrTx    int32
-	numTrHit   int32
-	numTxFetch int32
-
-	enabled bool
-
-	lastReset time.Time
-
-	chain *rpcclient.Client
-
-	trPrevOutCache *lru.Cache[wire.OutPoint, byteCacheEntry]
-}
-
-func newPrevOutCache(chain *rpcclient.Client,
-	prevOutCacheSizeMiB uint16) *prevOutCache {
-
-	return &prevOutCache{
-		enabled:   true,
-		chain:     chain,
-		lastReset: time.Now(),
-		trPrevOutCache: lru.NewCache[wire.OutPoint, byteCacheEntry](
-			uint64(prevOutCacheSizeMiB) * 1024 * 1024,
-		),
-	}
-}
-
-func (p *prevOutCache) LogAndReset() {
-	since := time.Since(p.lastReset).Seconds()
-	blockPerSecond := float64(p.numBlock) / since
-
-	log.Tracef("SP PrevOutCache: fetched %d previous txs (%d cache hits) "+
-		"for %d txns (%d with taproot outputs), cache size is %d, "+
-		"%.2f blocks per second", p.numTxFetch, p.numTrHit, p.numTx,
-		p.numTrTx, p.trPrevOutCache.Len(), blockPerSecond)
-
-	// Reset stats.
-	p.numBlock = 0
-	p.numTx = 0
-	p.numTrTx = 0
-	p.numTrHit = 0
-	p.numTxFetch = 0
-
-	p.lastReset = time.Now()
-}
-
-func (p *prevOutCache) Disable() {
-	p.enabled = false
-	p.trPrevOutCache = lru.NewCache[wire.OutPoint, byteCacheEntry](0)
-	p.LogAndReset()
-}
-
-// FetchPreviousOutputScript fetches the previous output's pkScript for the
-// given outpoint.
-func (p *prevOutCache) FetchPreviousOutputScript(op wire.OutPoint) ([]byte,
-	error) {
-
-	// We assume we only visit every transaction once, so each previous
-	// output we fetch is only fetched a single time. Thus, we can delete it
-	// from the cache after fetching it.
-	pkScript, ok := p.trPrevOutCache.LoadAndDelete(op)
-	if ok {
-		p.numTrHit++
-
-		return pkScript, nil
-	}
-
-	tx, err := p.chain.GetRawTransaction(&op.Hash)
-	if err != nil {
-		return nil, fmt.Errorf("error fetching previous transaction: "+
-			"%w", err)
-	}
-
-	p.numTxFetch++
-
-	if int(op.Index) >= len(tx.MsgTx().TxOut) {
-		return nil, fmt.Errorf("output index %d out of range for "+
-			"transaction %s", op.Index, op.Hash.String())
-	}
-
-	pkScript = tx.MsgTx().TxOut[op.Index].PkScript
-	if p.enabled {
-		_, _ = p.trPrevOutCache.Put(op, pkScript)
-	}
-
-	return pkScript, nil
-}
-
-func (p *prevOutCache) AddOutputs(tx *wire.MsgTx) {
-	if !p.enabled {
-		return
-	}
-
-	txHash := tx.TxHash()
-	for txIndex, txOut := range tx.TxOut {
-		if !txscript.IsPayToTaproot(txOut.PkScript) {
-			continue
-		}
-
-		_, _ = p.trPrevOutCache.Put(wire.OutPoint{
-			Hash:  txHash,
-			Index: uint32(txIndex),
-		}, txOut.PkScript)
-	}
-}
-
-func (p *prevOutCache) RemoveInputs(tx *wire.MsgTx) {
-	if !p.enabled {
-		return
-	}
-
-	for _, txIn := range tx.TxIn {
-		p.trPrevOutCache.Delete(txIn.PreviousOutPoint)
-	}
-}
-
 type spTweakFiles struct {
 	producerBase
 
@@ -200,7 +58,15 @@ type spTweakFiles struct {
 	// so we record it explicitly during ingest.
 	heightToHash map[int32]chainhash.Hash
 
-	prevOutCache *prevOutCache
+	// blockFetcher fetches blocks along with the previous output
+	// scripts spent by them.
+	blockFetcher *blockPrevOutFetcher
+
+	// numBlocksIndexed counts the blocks indexed since the last stats
+	// log line, which we emit whenever a file is sealed. Only accessed
+	// from the producer goroutine, so no locking is required.
+	numBlocksIndexed int32
+	statsLastReset   time.Time
 
 	// taprootStartHeight is the activation height for the current
 	// network, or a sentinel when Taproot isn't supported. Set once at
@@ -212,14 +78,15 @@ type spTweakFiles struct {
 func newSPTweakFiles(itemsPerFile, reOrgSafeDepth int32,
 	chain *rpcclient.Client, quit <-chan struct{}, baseDir string,
 	chainParams *chaincfg.Params, h2hCache *heightToHashCache,
-	prevOutCacheSizeMiB uint16) *spTweakFiles {
+	blockFetcher *blockPrevOutFetcher) *spTweakFiles {
 
 	taprootStartHeight, taprootSupported := TaprootActivationHeights[chainParams.Net]
 
 	s := &spTweakFiles{
 		tweakData:          make(map[int32]map[int32]*btcec.PublicKey),
 		heightToHash:       make(map[int32]chainhash.Hash),
-		prevOutCache:       newPrevOutCache(chain, prevOutCacheSizeMiB),
+		blockFetcher:       blockFetcher,
+		statsLastReset:     time.Now(),
 		taprootStartHeight: taprootStartHeight,
 		taprootSupported:   taprootSupported,
 	}
@@ -240,7 +107,6 @@ func newSPTweakFiles(itemsPerFile, reOrgSafeDepth int32,
 			writeSealedFile: s.writeSealedFile,
 			pruneLocked:     s.pruneLocked,
 			cachedHash:      s.cachedHash,
-			afterCatchUp:    s.prevOutCache.Disable,
 		},
 	}
 	s.lastSealedHeight.Store(-1)
@@ -289,12 +155,12 @@ func (s *spTweakFiles) ingest(height int32) error {
 		return nil
 	}
 
-	block, err := s.chain.GetBlock(hash)
+	block, err := s.blockFetcher.fetchBlock(hash)
 	if err != nil {
 		return fmt.Errorf("error getting block for SP tweak data: %w",
 			err)
 	}
-	s.prevOutCache.numBlock++
+	s.numBlocksIndexed++
 
 	if err := s.indexBlockSPTweakData(height, block); err != nil {
 		return fmt.Errorf("error indexing SP tweak data: %w", err)
@@ -312,11 +178,17 @@ func (s *spTweakFiles) writeSealedFile(fileStart, fileEnd int32) error {
 		return err
 	}
 
-	// Log + reset the prev-out cache stats now that we've written
-	// another batch of tweak data to disk. (The cache itself gets
-	// fully released by the afterCatchUp hook once the initial
-	// catch-up completes.)
-	s.prevOutCache.LogAndReset()
+	// Log the indexing throughput now that we've written another batch of
+	// tweak data to disk, so the initial catch-up progress can be
+	// observed.
+	since := time.Since(s.statsLastReset).Seconds()
+	log.Debugf("SP tweak data: indexed %d blocks in %.1fs (%.2f blocks "+
+		"per second)", s.numBlocksIndexed, since,
+		float64(s.numBlocksIndexed)/since)
+
+	s.numBlocksIndexed = 0
+	s.statsLastReset = time.Now()
+
 	return nil
 }
 
@@ -340,39 +212,28 @@ func (s *spTweakFiles) cachedHash(height int32) (chainhash.Hash, bool) {
 // Payments tweak data and store it in the provided index map, keyed by the
 // transaction index within the block.
 func (s *spTweakFiles) indexBlockSPTweakData(height int32,
-	block *wire.MsgBlock) error {
+	block *blockWithPrevOuts) error {
 
-	for txIndex, tx := range block.Transactions {
+	for txIndex, tx := range block.txs {
 		// Skip coinbase transactions, they can't contain Silent Payment
 		// outputs.
 		if blockchain.IsCoinBaseTx(tx) {
 			continue
 		}
 
-		s.prevOutCache.AddOutputs(tx)
-		s.prevOutCache.numTx++
-
-		// Only transactions with Taproot outputs can have Silent
-		// Payments.
-		if !sp.HasTaprootOutputs(tx) {
-			s.prevOutCache.RemoveInputs(tx)
-
-			continue
-		}
-		s.prevOutCache.numTrTx++
-
+		// The tweak calculation resolves the previous output scripts
+		// of all inputs from the data we got alongside the block, and
+		// returns a nil key for transactions that can't contain
+		// Silent Payment outputs.
 		tweakPubKey, err := sp.TransactionTweakData(
-			tx, s.prevOutCache.FetchPreviousOutputScript, log,
+			tx, block.fetchPrevOutScript, log,
 		)
 		if err != nil {
-			s.prevOutCache.RemoveInputs(tx)
-
 			return fmt.Errorf("error calculating SP tweak "+
 				"data for tx index %d in block at height "+
 				"%d: %w", txIndex, height, err)
 		}
 
-		s.prevOutCache.RemoveInputs(tx)
 		if tweakPubKey == nil {
 			continue
 		}

--- a/silent-payments-files.go
+++ b/silent-payments-files.go
@@ -59,8 +59,9 @@ type spTweakFiles struct {
 	heightToHash map[int32]chainhash.Hash
 
 	// blockFetcher fetches blocks along with the previous output
-	// scripts spent by them.
-	blockFetcher *blockPrevOutFetcher
+	// scripts spent by them, prefetching upcoming heights in the
+	// background.
+	blockFetcher *blockPrefetcher
 
 	// numBlocksIndexed counts the blocks indexed since the last stats
 	// log line, which we emit whenever a file is sealed. Only accessed
@@ -83,9 +84,11 @@ func newSPTweakFiles(itemsPerFile, reOrgSafeDepth int32,
 	taprootStartHeight, taprootSupported := TaprootActivationHeights[chainParams.Net]
 
 	s := &spTweakFiles{
-		tweakData:          make(map[int32]map[int32]*btcec.PublicKey),
-		heightToHash:       make(map[int32]chainhash.Hash),
-		blockFetcher:       blockFetcher,
+		tweakData:    make(map[int32]map[int32]*btcec.PublicKey),
+		heightToHash: make(map[int32]chainhash.Hash),
+		blockFetcher: newBlockPrefetcher(
+			blockFetcher, h2hCache,
+		),
 		statsLastReset:     time.Now(),
 		taprootStartHeight: taprootStartHeight,
 		taprootSupported:   taprootSupported,
@@ -155,7 +158,7 @@ func (s *spTweakFiles) ingest(height int32) error {
 		return nil
 	}
 
-	block, err := s.blockFetcher.fetchBlock(hash)
+	block, err := s.blockFetcher.fetchBlock(height, hash)
 	if err != nil {
 		return fmt.Errorf("error getting block for SP tweak data: %w",
 			err)

--- a/silent-payments-files_test.go
+++ b/silent-payments-files_test.go
@@ -72,7 +72,7 @@ func TestSPTweakDataFilesUpdate(t *testing.T) {
 	// Activate Taproot for regtest.
 	TaprootActivationHeights[chaincfg.RegressionNetParams.Net] = 1
 
-	miner, backend, _, _ := setupBackend(t, unitTestDir)
+	miner, backend, backendCfg, _ := setupBackend(t, unitTestDir)
 
 	// Mine initial blocks. The miner starts with 200 blocks already mined.
 	_ = miner.MineEmptyBlocks(initialBlocks - int(totalStartupBlocks))
@@ -86,7 +86,8 @@ func TestSPTweakDataFilesUpdate(t *testing.T) {
 	h2hCache := newH2HCache(backend)
 	hf := newSPTweakFiles(
 		tweakBlocksPerFile, testReOrgSafeDepth, backend, quit, dataDir,
-		&testParams, h2hCache, DefaultPrevOutCacheMiBytes,
+		&testParams, h2hCache,
+		newBlockPrevOutFetcher(backend, &backendCfg),
 	)
 
 	var wg sync.WaitGroup
@@ -120,7 +121,8 @@ func TestSPTweakDataFilesUpdate(t *testing.T) {
 	quit = make(chan struct{})
 	hf = newSPTweakFiles(
 		tweakBlocksPerFile, testReOrgSafeDepth, backend, quit, dataDir,
-		&testParams, h2hCache, DefaultPrevOutCacheMiBytes,
+		&testParams, h2hCache,
+		newBlockPrevOutFetcher(backend, &backendCfg),
 	)
 
 	// Wait for the final blocks to be written.
@@ -152,7 +154,7 @@ func TestSilentPaymentsDetection(t *testing.T) {
 	// Activate Taproot for regtest.
 	TaprootActivationHeights[chaincfg.RegressionNetParams.Net] = 1
 
-	miner, backend, _, bitcoindCfg := setupBackend(t, unitTestDir)
+	miner, backend, backendCfg, bitcoindCfg := setupBackend(t, unitTestDir)
 	wallet, scopeMgr := newTestWallet(
 		t, &testParams, bitcoindCfg, seedBytes,
 	)
@@ -169,7 +171,8 @@ func TestSilentPaymentsDetection(t *testing.T) {
 	h2hCache := newH2HCache(backend)
 	hf := newSPTweakFiles(
 		tweakBlocksPerFile, testReOrgSafeDepth, backend, quit, dataDir,
-		&testParams, h2hCache, DefaultPrevOutCacheMiBytes,
+		&testParams, h2hCache,
+		newBlockPrevOutFetcher(backend, &backendCfg),
 	)
 
 	// Wait for the initial blocks to be written.


### PR DESCRIPTION
Adds a bunch of optimizations:
 - Use the new REST `/spenttxouts/` endpoint to fetch previous outputs for a block.
 - Prefetch the above call for 8 blocks to speed up processing.
 - Remove previous output cache.
 - Fix file sealing.