### PR TITLE
Add custom, output-type-restricted compact filter and filter headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Flags:
       --bitcoind-pass string      The RPC password of the bitcoind instance to connect to
       --bitcoind-user string      The RPC username of the bitcoind instance to connect to
   -h, --help                      help for block-dn
+      --index-custom-filters      Indicates if the server should build custom output-type-restricted compact filters (four sets: segwit, p2wpkh, p2wsh, p2tr); adds about 8 GB more data as of block 950k; requires bitcoind v30.0 or later with the REST API enabled (rest=1)
       --index-page string         Full path to the index.html that should be used instead of the default one that comes with the project
       --index-sp-tweak-data       Indicates if the server should index BIP-0352 Silent Payments tweak data that allows light clients to scan the chain for inbound SP more efficiently; this requires every block since the activation of Taproot to be indexed which may take a while; requires bitcoind v30.0 or later with the REST API enabled (rest=1)
       --light-mode                Indicates if the server should run in light mode which creates no files on disk and therefore requires zero disk space; but only the status and block endpoints are available in this mode

--- a/block-prevouts.go
+++ b/block-prevouts.go
@@ -43,11 +43,12 @@ const (
 	// inputs) than its serialized size in bytes.
 	maxSpentTxOutsPerBlock = wire.MaxBlockPayload
 
-	// minSPTweakBackendVersion is the minimum bitcoind version (in the
+	// minPrevOutBackendVersion is the minimum bitcoind version (in the
 	// numeric format reported by getnetworkinfo) we require for indexing
-	// SP tweak data: v30.0 is the first version that serves a block's
-	// spent outputs through the /rest/spenttxouts endpoint.
-	minSPTweakBackendVersion = 300_000
+	// data derived from previous outputs (SP tweak data and custom
+	// filters): v30.0 is the first version that serves a block's spent
+	// outputs through the /rest/spenttxouts endpoint.
+	minPrevOutBackendVersion = 300_000
 
 	// prefetchDepth is the number of blocks the prefetcher keeps in
 	// flight ahead of the block currently being processed, hiding the
@@ -341,14 +342,14 @@ func (f *blockPrevOutFetcher) requireREST() error {
 	return nil
 }
 
-// verifySPTweakBackendVersion returns an error if the given backend version
+// verifyPrevOutBackendVersion returns an error if the given backend version
 // (in the numeric format reported by getnetworkinfo) is too old for indexing
-// SP tweak data.
-func verifySPTweakBackendVersion(version int32) error {
-	if version < minSPTweakBackendVersion {
-		return fmt.Errorf("indexing SP tweak data requires bitcoind "+
-			"v30.0 or later, but the backend reports version %d",
-			version)
+// data derived from previous outputs.
+func verifyPrevOutBackendVersion(version int32) error {
+	if version < minPrevOutBackendVersion {
+		return fmt.Errorf("indexing SP tweak data or custom filters "+
+			"requires bitcoind v30.0 or later, but the backend "+
+			"reports version %d", version)
 	}
 
 	return nil

--- a/block-prevouts_test.go
+++ b/block-prevouts_test.go
@@ -311,13 +311,13 @@ func TestBlockPrefetcherFailedPrefetch(t *testing.T) {
 			"prefetch")
 }
 
-// TestVerifySPTweakBackendVersion pins the minimum backend version required
+// TestVerifyPrevOutBackendVersion pins the minimum backend version required
 // for indexing SP tweak data.
-func TestVerifySPTweakBackendVersion(t *testing.T) {
-	require.Error(t, verifySPTweakBackendVersion(250_000))
-	require.Error(t, verifySPTweakBackendVersion(299_900))
-	require.NoError(t, verifySPTweakBackendVersion(300_000))
-	require.NoError(t, verifySPTweakBackendVersion(310_100))
+func TestVerifyPrevOutBackendVersion(t *testing.T) {
+	require.Error(t, verifyPrevOutBackendVersion(250_000))
+	require.Error(t, verifyPrevOutBackendVersion(299_900))
+	require.NoError(t, verifyPrevOutBackendVersion(300_000))
+	require.NoError(t, verifyPrevOutBackendVersion(310_100))
 }
 
 // TestGetBlockWithPrevOuts checks that fetching a block through the getblock

--- a/block-prevouts_test.go
+++ b/block-prevouts_test.go
@@ -80,7 +80,7 @@ func TestParseSpentTxOuts(t *testing.T) {
 // same result as the getblock verbosity 3 RPC, and that the fetcher falls
 // back to the RPC when the backend's REST API isn't reachable.
 func TestBlockPrevOutFetcher(t *testing.T) {
-	miner, backend, backendCfg, _ := setupBackend(t, unitTestDir)
+	miner, backend, backendCfg, _ := setupBackend(t)
 
 	// Create a transaction spending miner outputs, so the next block
 	// contains a non-coinbase transaction with previous output data.
@@ -325,7 +325,7 @@ func TestVerifyPrevOutBackendVersion(t *testing.T) {
 // getblock RPC, and that the previous output scripts collected from the undo
 // data match the outputs of the referenced transactions.
 func TestGetBlockWithPrevOuts(t *testing.T) {
-	miner, backend, _, _ := setupBackend(t, unitTestDir)
+	miner, backend, _, _ := setupBackend(t)
 
 	// Create a transaction spending miner outputs, so the next block
 	// contains a non-coinbase transaction with previous output data.

--- a/cfilter-files_test.go
+++ b/cfilter-files_test.go
@@ -18,8 +18,7 @@ const (
 )
 
 func TestCFilterFilesUpdate(t *testing.T) {
-	testDir := ".unit-test-logs"
-	miner, backend, _, _ := setupBackend(t, testDir)
+	miner, backend, _, _ := setupBackend(t)
 
 	// Mine initial blocks. The miner starts with 200 blocks already mined.
 	_ = miner.MineEmptyBlocks(initialBlocks - int(totalStartupBlocks))

--- a/custom-filter-files.go
+++ b/custom-filter-files.go
@@ -65,6 +65,18 @@ var customFilterConfigs = []customFilterConfig{
 	},
 }
 
+// customFilterConfigIndex returns the index of the custom filter
+// configuration with the given name.
+func customFilterConfigIndex(name string) (int, bool) {
+	for i, cfg := range customFilterConfigs {
+		if cfg.name == name {
+			return i, true
+		}
+	}
+
+	return 0, false
+}
+
 // customFilterDir returns the directory (relative to the base directory) the
 // filter files of the given configuration are stored in.
 func customFilterDir(name string) string {
@@ -630,6 +642,42 @@ func (c *customFilterFiles) cachedHash(height int32) (chainhash.Hash, bool) {
 
 	hash, ok := c.heightToHash[height]
 	return hash, ok
+}
+
+// filtersSize returns the exact serialized size of the var-int prefixed
+// filters of the given configuration index in [startIndex, endIndex], or
+// false if any of them is missing from the in-memory tail.
+func (c *customFilterFiles) filtersSize(cfgIndex int, startIndex,
+	endIndex int32) (int64, bool) {
+
+	c.RLock()
+	defer c.RUnlock()
+
+	var total int64
+	for j := startIndex; j <= endIndex; j++ {
+		filters, ok := c.filters[j]
+		if !ok {
+			return 0, false
+		}
+
+		filter := filters[cfgIndex]
+		total += int64(wire.VarIntSerializeSize(uint64(len(filter)))) +
+			int64(len(filter))
+	}
+
+	return total, true
+}
+
+// filterHeadersSize returns the exact serialized size of the filter headers
+// in [startIndex, endIndex]; each one is a 32-byte hash.
+func (c *customFilterFiles) filterHeadersSize(startIndex, endIndex int32) (
+	int64, bool) {
+
+	if endIndex < startIndex {
+		return 0, false
+	}
+
+	return int64(endIndex-startIndex+1) * chainhash.HashSize, true
 }
 
 // serializeFilters writes the var-int prefixed filters of the given

--- a/custom-filter-files.go
+++ b/custom-filter-files.go
@@ -1,0 +1,704 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil/v2/gcs"
+	"github.com/btcsuite/btcd/btcutil/v2/gcs/builder"
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/rpcclient"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+)
+
+// scriptTypes is a bit mask of the output script types a custom filter
+// configuration includes.
+type scriptTypes uint8
+
+const (
+	scriptTypeP2WPKH scriptTypes = 1 << iota
+	scriptTypeP2WSH
+	scriptTypeP2TR
+)
+
+// customFilterConfig describes one output-type-restricted filter set.
+type customFilterConfig struct {
+	// name identifies the set and is used in the on-disk directory
+	// names (filters/custom-<name> and headers/custom-<name>).
+	name string
+
+	// types is the set of output script types whose scripts are
+	// included in this filter.
+	types scriptTypes
+}
+
+// customFilterConfigs are the filter sets the custom filter producer builds
+// in a single pass over the chain. The first entry additionally serves as
+// the producer's resume anchor: its filter directory is the producer's
+// subDir and its files are written last in each sealed batch, so its file's
+// presence on disk implies the whole batch is durable.
+var customFilterConfigs = []customFilterConfig{
+	{
+		name: "segwit",
+		types: scriptTypeP2WPKH | scriptTypeP2WSH |
+			scriptTypeP2TR,
+	},
+	{
+		name:  "p2wpkh",
+		types: scriptTypeP2WPKH,
+	},
+	{
+		name:  "p2wsh",
+		types: scriptTypeP2WSH,
+	},
+	{
+		name:  "p2tr",
+		types: scriptTypeP2TR,
+	},
+}
+
+// customFilterDir returns the directory (relative to the base directory) the
+// filter files of the given configuration are stored in.
+func customFilterDir(name string) string {
+	return filepath.Join(FilterFileDir, "custom-"+name)
+}
+
+// customHeaderDir returns the directory (relative to the base directory) the
+// filter header files of the given configuration are stored in.
+func customHeaderDir(name string) string {
+	return filepath.Join(HeaderFileDir, "custom-"+name)
+}
+
+// classifyScript returns the type bit of the given output script, or zero if
+// it's none of the types custom filters can be restricted to.
+func classifyScript(pkScript []byte) scriptTypes {
+	switch {
+	case txscript.IsPayToWitnessPubKeyHash(pkScript):
+		return scriptTypeP2WPKH
+
+	case txscript.IsPayToWitnessScriptHash(pkScript):
+		return scriptTypeP2WSH
+
+	case txscript.IsPayToTaproot(pkScript):
+		return scriptTypeP2TR
+
+	default:
+		return 0
+	}
+}
+
+// buildCustomFilters builds one output-type-restricted filter per
+// configuration from a single pass over the given block. The filters use the
+// exact same parameters as bitcoind's BIP-0158 basic filters (P=19,
+// M=784931, SipHash key derived from the block hash, elements de-duplicated
+// by script); they only differ in which elements are included: the output
+// scripts of matching types created by the block, plus the previous output
+// scripts of matching types spent by it. The type restriction subsumes the
+// basic filter's exclusion of empty and OP_RETURN scripts.
+func buildCustomFilters(hash *chainhash.Hash,
+	block *blockWithPrevOuts) ([]*gcs.Filter, error) {
+
+	builders := make([]*builder.GCSBuilder, len(customFilterConfigs))
+	for i := range customFilterConfigs {
+		builders[i] = builder.WithKeyHash(hash)
+	}
+
+	addScript := func(pkScript []byte) {
+		types := classifyScript(pkScript)
+		if types == 0 {
+			return
+		}
+
+		for i := range customFilterConfigs {
+			if customFilterConfigs[i].types&types != 0 {
+				builders[i].AddEntry(pkScript)
+			}
+		}
+	}
+
+	for _, tx := range block.txs {
+		for _, txOut := range tx.TxOut {
+			addScript(txOut.PkScript)
+		}
+	}
+	for _, pkScript := range block.prevOutScripts {
+		addScript(pkScript)
+	}
+
+	filters := make([]*gcs.Filter, len(customFilterConfigs))
+	for i, b := range builders {
+		filter, err := b.Build()
+		if err != nil {
+			return nil, fmt.Errorf("error building custom filter "+
+				"%s: %w", customFilterConfigs[i].name, err)
+		}
+
+		filters[i] = filter
+	}
+
+	return filters, nil
+}
+
+// customFilterFiles is a producer that builds multiple sets of
+// output-type-restricted compact filters (plus their BIP-0157 filter header
+// chains) in a single scan over the chain, to compare their sizes against
+// the basic filters. The files aren't served over any endpoint yet.
+type customFilterFiles struct {
+	producerBase
+
+	// blockFetcher fetches blocks along with the previous output
+	// scripts spent by them, prefetching upcoming heights in the
+	// background.
+	blockFetcher *blockPrefetcher
+
+	// filters holds, per unsealed height, the serialized filter of
+	// every configuration, indexed like customFilterConfigs.
+	filters map[int32][][]byte
+
+	// filterHeaders holds, per height, the filter header of every
+	// configuration, indexed like customFilterConfigs. Unlike the
+	// filters, the headers live in files of headersPerFile entries, so
+	// they're retained in memory until their (much larger) file is
+	// sealed; at the mainnet defaults that's up to 100k heights of five
+	// 32-byte hashes, about 16 MiB. After a restart the unsealed window
+	// is rebuilt from the sealed filter files on disk.
+	filterHeaders map[int32][]chainhash.Hash
+
+	// headersPerFile is the number of entries per filter header file.
+	// It must be a multiple of the producer's entriesPerFile (the
+	// filters per file), so every header file boundary coincides with a
+	// filter file boundary.
+	headersPerFile int32
+
+	// heightToHash mirrors cFilterFiles: see the comment there.
+	heightToHash map[int32]chainhash.Hash
+
+	// numBlocksIndexed counts the blocks indexed since the last stats
+	// log line, which we emit whenever a file is sealed. Together with
+	// the fetch/compute split below it shows where the indexing time
+	// goes. Only accessed from the producer goroutine, so no locking is
+	// required.
+	numBlocksIndexed int32
+	statsFetchWait   time.Duration
+	statsCompute     time.Duration
+	statsLastReset   time.Time
+}
+
+// newCustomFilterFiles creates a new custom filter producer writing filter
+// files of itemsPerFile entries and filter header files of headersPerFile
+// entries (which must be a multiple of itemsPerFile) below the given base
+// directory.
+func newCustomFilterFiles(itemsPerFile, headersPerFile,
+	reOrgSafeDepth int32, chain *rpcclient.Client, quit <-chan struct{},
+	baseDir string, chainParams *chaincfg.Params,
+	h2hCache *heightToHashCache,
+	blockFetcher *blockPrevOutFetcher) *customFilterFiles {
+
+	c := &customFilterFiles{
+		filters:        make(map[int32][][]byte),
+		filterHeaders:  make(map[int32][]chainhash.Hash),
+		heightToHash:   make(map[int32]chainhash.Hash),
+		headersPerFile: headersPerFile,
+		blockFetcher: newBlockPrefetcher(
+			blockFetcher, h2hCache,
+		),
+		statsLastReset: time.Now(),
+	}
+	c.producerBase = producerBase{
+		quit:        quit,
+		chain:       chain,
+		h2hCache:    h2hCache,
+		chainParams: chainParams,
+		name:        "custom filter",
+		baseDir:     baseDir,
+
+		// The first configuration's filter directory doubles as the
+		// resume directory; see writeSealedFile for the invariant
+		// that makes this safe.
+		subDir:         customFilterDir(customFilterConfigs[0].name),
+		fileSuffix:     FilterFileSuffix,
+		extractRegex:   filterFileNameExtractRegex,
+		entriesPerFile: itemsPerFile,
+		reOrgSafeDepth: reOrgSafeDepth,
+		hooks: producerHooks{
+			ingest:          c.ingest,
+			writeSealedFile: c.writeSealedFile,
+			pruneLocked:     c.pruneLocked,
+			cachedHash:      c.cachedHash,
+		},
+	}
+	c.lastSealedHeight.Store(-1)
+
+	return c
+}
+
+// updateFiles shadows producerBase.updateFiles to validate the file sizing
+// and to create the per-set filter and header directories first; the base
+// only creates the single resume directory (subDir).
+func (c *customFilterFiles) updateFiles(numBlocks int32) error {
+	if c.headersPerFile <= 0 ||
+		c.headersPerFile%c.entriesPerFile != 0 {
+
+		return fmt.Errorf("custom filter headers per file (%d) must "+
+			"be a positive multiple of the filters per file (%d)",
+			c.headersPerFile, c.entriesPerFile)
+	}
+
+	for _, cfg := range customFilterConfigs {
+		dirs := []string{
+			customFilterDir(cfg.name), customHeaderDir(cfg.name),
+		}
+		for _, dir := range dirs {
+			path := filepath.Join(c.baseDir, dir)
+			err := os.MkdirAll(path, DirectoryMode)
+			if err != nil {
+				return fmt.Errorf("error creating directory "+
+					"%s: %w", path, err)
+			}
+		}
+	}
+
+	return c.producerBase.updateFiles(numBlocks)
+}
+
+// ingest builds the filters and filter headers of every configuration for
+// the block at the given height.
+func (c *customFilterFiles) ingest(height int32) error {
+	hash, err := c.h2hCache.getBlockHash(height)
+	if err != nil {
+		return fmt.Errorf("error getting block hash for height %d: %w",
+			height, err)
+	}
+
+	prevHeaders, err := c.prevFilterHeaders(height)
+	if err != nil {
+		return fmt.Errorf("error getting previous filter headers "+
+			"for height %d: %w", height, err)
+	}
+
+	fetchStart := time.Now()
+	block, err := c.blockFetcher.fetchBlock(height, hash)
+	if err != nil {
+		return fmt.Errorf("error getting block for custom filters: "+
+			"%w", err)
+	}
+	c.numBlocksIndexed++
+	c.statsFetchWait += time.Since(fetchStart)
+
+	computeStart := time.Now()
+	filters, err := buildCustomFilters(hash, block)
+	if err != nil {
+		return fmt.Errorf("error building custom filters for height "+
+			"%d: %w", height, err)
+	}
+
+	serialized := make([][]byte, len(customFilterConfigs))
+	headers := make([]chainhash.Hash, len(customFilterConfigs))
+	for i, filter := range filters {
+		serialized[i], err = filter.NBytes()
+		if err != nil {
+			return fmt.Errorf("error serializing custom filter "+
+				"%s at height %d: %w",
+				customFilterConfigs[i].name, height, err)
+		}
+
+		headers[i] = filterHeaderFromBytes(
+			serialized[i], &prevHeaders[i],
+		)
+	}
+	c.statsCompute += time.Since(computeStart)
+
+	c.Lock()
+	c.filters[height] = serialized
+	c.filterHeaders[height] = headers
+	c.heightToHash[height] = *hash
+	c.Unlock()
+
+	return nil
+}
+
+// filterHeaderFromBytes computes the BIP-0157 filter header for a serialized
+// filter, chaining onto the previous height's header:
+// double-SHA256(double-SHA256(filter) || prevHeader).
+func filterHeaderFromBytes(filterBytes []byte,
+	prevHeader *chainhash.Hash) chainhash.Hash {
+
+	filterHash := chainhash.DoubleHashB(filterBytes)
+	return chainhash.DoubleHashH(append(filterHash, prevHeader[:]...))
+}
+
+// prevFilterHeaders returns the filter header of height-1 for every
+// configuration, which the headers at the given height chain onto. For the
+// genesis block that's an all-zero header per BIP-0157. After a restart the
+// previous height's headers are no longer in memory and the unsealed part of
+// the header chain is rebuilt from the files on disk instead.
+func (c *customFilterFiles) prevFilterHeaders(height int32) ([]chainhash.Hash,
+	error) {
+
+	if height == 0 {
+		return make([]chainhash.Hash, len(customFilterConfigs)), nil
+	}
+
+	c.RLock()
+	headers, ok := c.filterHeaders[height-1]
+	c.RUnlock()
+
+	if ok {
+		return headers, nil
+	}
+
+	return c.resumeFilterHeaders(height)
+}
+
+// resumeFilterHeaders re-creates the in-memory filter header state after a
+// restart, where the given height is the first one after the last sealed
+// filter file. The chain is anchored at the last sealed header file (or the
+// genesis all-zero header) and the span not yet covered by a header file is
+// recomputed from the sealed filter files, repopulating the in-memory map so
+// the next header file can be sealed. The final chain state (the headers of
+// height-1) is returned.
+func (c *customFilterFiles) resumeFilterHeaders(
+	height int32) ([]chainhash.Hash, error) {
+
+	// The sealed header files cover [0, anchorCount-1]; every filter
+	// file boundary is a potential resume point, but header files only
+	// exist at multiples of headersPerFile.
+	anchorCount := (height / c.headersPerFile) * c.headersPerFile
+
+	prevHeaders := make([]chainhash.Hash, len(customFilterConfigs))
+	if anchorCount > 0 {
+		anchors, err := c.readHeaderFileAnchor(anchorCount - 1)
+		if err != nil {
+			return nil, err
+		}
+		prevHeaders = anchors
+	}
+
+	if anchorCount == height {
+		return prevHeaders, nil
+	}
+
+	return c.rebuildFilterHeaders(prevHeaders, anchorCount, height-1)
+}
+
+// readHeaderFileAnchor reads the filter header of every configuration for
+// the given height, which must be the last height of a sealed header file,
+// from the header files on disk.
+func (c *customFilterFiles) readHeaderFileAnchor(
+	height int32) ([]chainhash.Hash, error) {
+
+	fileStart := height + 1 - c.headersPerFile
+	headers := make([]chainhash.Hash, len(customFilterConfigs))
+	for i, cfg := range customFilterConfigs {
+		headerDir := filepath.Join(
+			c.baseDir, customHeaderDir(cfg.name),
+		)
+		fileName := fmt.Sprintf(
+			FilterHeaderFileNamePattern, headerDir, fileStart,
+			height,
+		)
+
+		data, err := os.ReadFile(fileName)
+		if err != nil {
+			return nil, fmt.Errorf("error reading filter header "+
+				"file to resume the header chain: %w", err)
+		}
+
+		expectedSize := int(c.headersPerFile) * chainhash.HashSize
+		if len(data) != expectedSize {
+			return nil, fmt.Errorf("unexpected size %d of filter "+
+				"header file %s, expected %d", len(data),
+				fileName, expectedSize)
+		}
+
+		copy(headers[i][:], data[len(data)-chainhash.HashSize:])
+	}
+
+	return headers, nil
+}
+
+// rebuildFilterHeaders recomputes the filter header chains for the given
+// (inclusive, filter-file-aligned) height range from the sealed filter files
+// on disk, chaining onto prevHeaders. The computed headers are stored in the
+// in-memory map, since they're still needed to seal their header file later,
+// and the final chain state is returned.
+func (c *customFilterFiles) rebuildFilterHeaders(prevHeaders []chainhash.Hash,
+	start, end int32) ([]chainhash.Hash, error) {
+
+	log.Debugf("Rebuilding custom filter headers for heights %d-%d from "+
+		"sealed filter files", start, end)
+
+	prev := slices.Clone(prevHeaders)
+	for fileStart := start; fileStart <= end; fileStart += c.entriesPerFile {
+		fileEnd := fileStart + c.entriesPerFile - 1
+
+		rows := make([][]chainhash.Hash, c.entriesPerFile)
+		for r := range rows {
+			rows[r] = make(
+				[]chainhash.Hash, len(customFilterConfigs),
+			)
+		}
+
+		for i, cfg := range customFilterConfigs {
+			filterDir := filepath.Join(
+				c.baseDir, customFilterDir(cfg.name),
+			)
+			fileName := fmt.Sprintf(
+				FilterFileNamePattern, filterDir, fileStart,
+				fileEnd,
+			)
+
+			numRead, err := readFilterFile(
+				fileName, func(idx int32, filter []byte) {
+					// Corrupt oversized files are caught
+					// through the entry count below.
+					if idx >= int32(len(rows)) {
+						return
+					}
+
+					prev[i] = filterHeaderFromBytes(
+						filter, &prev[i],
+					)
+					rows[idx][i] = prev[i]
+				},
+			)
+			if err != nil {
+				return nil, fmt.Errorf("error rebuilding "+
+					"filter headers from %s: %w", fileName,
+					err)
+			}
+			if numRead != c.entriesPerFile {
+				return nil, fmt.Errorf("filter file %s has "+
+					"%d entries, expected %d", fileName,
+					numRead, c.entriesPerFile)
+			}
+		}
+
+		c.Lock()
+		for r, headers := range rows {
+			c.filterHeaders[fileStart+int32(r)] = headers
+		}
+		c.Unlock()
+	}
+
+	return prev, nil
+}
+
+// readFilterFile reads a sealed filter file and invokes the callback for
+// every var-int prefixed filter in it, with the entry's index within the
+// file. It returns the number of entries read; the caller is responsible
+// for making sure the callback can handle that many.
+func readFilterFile(fileName string,
+	each func(idx int32, filter []byte)) (int32, error) {
+
+	file, err := os.Open(fileName)
+	if err != nil {
+		return 0, fmt.Errorf("error opening file: %w", err)
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	reader := bufio.NewReader(file)
+	for idx := int32(0); ; idx++ {
+		filter, err := wire.ReadVarBytes(
+			reader, 0, wire.MaxMessagePayload, "filter",
+		)
+		if errors.Is(err, io.EOF) {
+			return idx, nil
+		}
+		if err != nil {
+			return idx, fmt.Errorf("error reading filter %d: %w",
+				idx, err)
+		}
+
+		each(idx, filter)
+	}
+}
+
+// writeSealedFile writes the filter files of every configuration for the
+// just-sealed range and, whenever the range completes a filter header file
+// span, the (larger) filter header files as well. The first configuration's
+// filter file is written last: its directory is the producer's resume
+// directory, so its file must only appear on disk once all other files of
+// the batch are durable. A crash in between re-ingests the last filter
+// batch on restart and rewrites all of its files.
+func (c *customFilterFiles) writeSealedFile(fileStart, fileEnd int32) error {
+	// The header files hold headersPerFile entries (a multiple of the
+	// filters per file), so they seal together with the filter batch
+	// that completes their span.
+	if (fileEnd+1)%c.headersPerFile == 0 {
+		if err := c.writeFilterHeaderFiles(fileEnd); err != nil {
+			return err
+		}
+	}
+
+	for i, cfg := range slices.Backward(customFilterConfigs) {
+		filterDir := filepath.Join(
+			c.baseDir, customFilterDir(cfg.name),
+		)
+		filterFile := fmt.Sprintf(
+			FilterFileNamePattern, filterDir, fileStart, fileEnd,
+		)
+		err := createAndWrite(filterFile, func(w io.Writer) error {
+			return c.serializeFilters(w, i, fileStart, fileEnd)
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	// Log the indexing throughput now that we've written another batch
+	// of filter files to disk, so the initial catch-up progress can be
+	// observed.
+	since := time.Since(c.statsLastReset).Seconds()
+	log.Debugf("Custom filters: indexed %d blocks in %.1fs (%.2f blocks "+
+		"per second; %.1fs waiting on block fetch, %.1fs computing "+
+		"filters)", c.numBlocksIndexed, since,
+		float64(c.numBlocksIndexed)/since,
+		c.statsFetchWait.Seconds(), c.statsCompute.Seconds())
+
+	c.numBlocksIndexed = 0
+	c.statsFetchWait = 0
+	c.statsCompute = 0
+	c.statsLastReset = time.Now()
+
+	return nil
+}
+
+// pruneLocked drops the in-memory filter entries for [start, end]. The
+// filter headers are deliberately not touched here: they're pruned by
+// writeFilterHeaderFiles once their (larger) file is sealed. For rollback
+// prunes that leaves stale header entries above the rollback height in
+// memory, which is harmless: the sequential re-ingest overwrites each height
+// before its entry is read again.
+func (c *customFilterFiles) pruneLocked(start, end int32) {
+	for j := start; j <= end; j++ {
+		delete(c.filters, j)
+		delete(c.heightToHash, j)
+	}
+}
+
+// writeFilterHeaderFiles writes the filter header file of every
+// configuration for the span ending at the given height, then prunes the
+// span's header entries from memory: the heights above it are all still
+// present (sealing lags the tip by the reorg-safe depth) and a restart
+// rebuilds its state from the files on disk.
+func (c *customFilterFiles) writeFilterHeaderFiles(fileEnd int32) error {
+	fileStart := fileEnd + 1 - c.headersPerFile
+
+	for i, cfg := range customFilterConfigs {
+		headerDir := filepath.Join(
+			c.baseDir, customHeaderDir(cfg.name),
+		)
+		headerFile := fmt.Sprintf(
+			FilterHeaderFileNamePattern, headerDir, fileStart,
+			fileEnd,
+		)
+		err := createAndWrite(headerFile, func(w io.Writer) error {
+			return c.serializeFilterHeaders(
+				w, i, fileStart, fileEnd,
+			)
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	c.Lock()
+	for j := fileStart; j <= fileEnd; j++ {
+		delete(c.filterHeaders, j)
+	}
+	c.Unlock()
+
+	return nil
+}
+
+// cachedHash returns the block hash this producer has recorded for the given
+// in-memory height. Used by the base's reorg detection.
+func (c *customFilterFiles) cachedHash(height int32) (chainhash.Hash, bool) {
+	c.RLock()
+	defer c.RUnlock()
+
+	hash, ok := c.heightToHash[height]
+	return hash, ok
+}
+
+// serializeFilters writes the var-int prefixed filters of the given
+// configuration index for [startIndex, endIndex] to w, in the same format
+// the basic filter files use.
+func (c *customFilterFiles) serializeFilters(w io.Writer, cfgIndex int,
+	startIndex, endIndex int32) error {
+
+	c.RLock()
+	defer c.RUnlock()
+
+	for j := startIndex; j <= endIndex; j++ {
+		filters, ok := c.filters[j]
+		if !ok {
+			return fmt.Errorf("missing custom filter at height "+
+				"%d", j)
+		}
+
+		if err := wire.WriteVarBytes(w, 0, filters[cfgIndex]); err != nil {
+			return fmt.Errorf("error writing filters: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// serializeFilterHeaders writes the raw 32-byte filter headers of the given
+// configuration index for [startIndex, endIndex] to w, in the same format
+// the basic filter header files use.
+func (c *customFilterFiles) serializeFilterHeaders(w io.Writer, cfgIndex int,
+	startIndex, endIndex int32) error {
+
+	c.RLock()
+	defer c.RUnlock()
+
+	for j := startIndex; j <= endIndex; j++ {
+		headers, ok := c.filterHeaders[j]
+		if !ok {
+			return fmt.Errorf("missing custom filter header at "+
+				"height %d", j)
+		}
+
+		if _, err := w.Write(headers[cfgIndex][:]); err != nil {
+			return fmt.Errorf("error writing filter headers: %w",
+				err)
+		}
+	}
+
+	return nil
+}
+
+// createAndWrite creates fileName and fills it with the output of the given
+// write closure, mirroring the create/write/close handling of the other
+// producers.
+func createAndWrite(fileName string, write func(io.Writer) error) error {
+	log.Debugf("Writing custom filter file %s", fileName)
+	file, err := os.Create(fileName)
+	if err != nil {
+		return fmt.Errorf("error creating file %s: %w", fileName, err)
+	}
+
+	if err := write(file); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("error writing file %s: %w", fileName, err)
+	}
+
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("error closing file %s: %w", fileName, err)
+	}
+
+	return nil
+}

--- a/custom-filter-files_test.go
+++ b/custom-filter-files_test.go
@@ -158,7 +158,7 @@ func TestBuildCustomFilters(t *testing.T) {
 // the on-disk filter header chains from genesis and checks that a restart
 // resumes the header chains correctly from disk.
 func TestCustomFilterFilesUpdate(t *testing.T) {
-	miner, backend, backendCfg, _ := setupBackend(t, unitTestDir)
+	miner, backend, backendCfg, _ := setupBackend(t)
 
 	// Mine initial blocks. The miner starts with 200 blocks already
 	// mined.

--- a/custom-filter-files_test.go
+++ b/custom-filter-files_test.go
@@ -1,0 +1,386 @@
+package main
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil/v2/gcs"
+	"github.com/btcsuite/btcd/btcutil/v2/gcs/builder"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	customBlocksPerFile = 100
+
+	// customHeadersPerFile deliberately spans multiple filter files but
+	// doesn't align with where the tests stop and restart the producer,
+	// so the restart has to rebuild part of the header chain from the
+	// sealed filter files.
+	customHeadersPerFile = 300
+)
+
+var (
+	testScriptP2WPKH = append(
+		[]byte{0x00, 0x14}, bytes.Repeat([]byte{0x01}, 20)...,
+	)
+	testScriptP2WSH = append(
+		[]byte{0x00, 0x20}, bytes.Repeat([]byte{0x02}, 32)...,
+	)
+	testScriptP2TR = append(
+		[]byte{0x51, 0x20}, bytes.Repeat([]byte{0x03}, 32)...,
+	)
+	testScriptP2PKH = append(append(
+		[]byte{0x76, 0xa9, 0x14}, bytes.Repeat([]byte{0x04}, 20)...),
+		0x88, 0xac,
+	)
+	testScriptOpReturn = []byte{0x6a, 0x02, 0x05, 0x05}
+)
+
+// TestClassifyScript pins the script type classification the custom filter
+// configurations are based on.
+func TestClassifyScript(t *testing.T) {
+	require.Equal(t, scriptTypeP2WPKH, classifyScript(testScriptP2WPKH))
+	require.Equal(t, scriptTypeP2WSH, classifyScript(testScriptP2WSH))
+	require.Equal(t, scriptTypeP2TR, classifyScript(testScriptP2TR))
+	require.Equal(t, scriptTypes(0), classifyScript(testScriptP2PKH))
+	require.Equal(t, scriptTypes(0), classifyScript(testScriptOpReturn))
+	require.Equal(t, scriptTypes(0), classifyScript(nil))
+}
+
+// TestBuildCustomFilters checks that each configuration's filter contains
+// exactly the scripts of its configured types, from both the block's outputs
+// and its spent previous outputs, with duplicates removed.
+func TestBuildCustomFilters(t *testing.T) {
+	blockHash := chainhash.DoubleHashH([]byte("custom filter test block"))
+	key := builder.DeriveKey(&blockHash)
+
+	// One transaction creates a p2wpkh (twice, to check de-duplication),
+	// a p2pkh and an OP_RETURN output; its inputs spend a p2wsh and a
+	// p2pkh output. A p2tr script is only visible on the input side.
+	tx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{
+			{PreviousOutPoint: wire.OutPoint{Index: 0}},
+			{PreviousOutPoint: wire.OutPoint{Index: 1}},
+			{PreviousOutPoint: wire.OutPoint{Index: 2}},
+		},
+		TxOut: []*wire.TxOut{
+			{PkScript: testScriptP2WPKH},
+			{PkScript: testScriptP2WPKH},
+			{PkScript: testScriptP2PKH},
+			{PkScript: testScriptOpReturn},
+		},
+	}
+	block := &blockWithPrevOuts{
+		txs: []*wire.MsgTx{tx},
+		prevOutScripts: map[wire.OutPoint][]byte{
+			{Index: 0}: testScriptP2WSH,
+			{Index: 1}: testScriptP2TR,
+			{Index: 2}: testScriptP2PKH,
+		},
+	}
+
+	filters, err := buildCustomFilters(&blockHash, block)
+	require.NoError(t, err)
+	require.Len(t, filters, len(customFilterConfigs))
+
+	// expectedScripts maps the configuration name to the scripts its
+	// filter must (and must not) contain.
+	expectedScripts := map[string][][]byte{
+		"segwit": {
+			testScriptP2WPKH, testScriptP2WSH, testScriptP2TR,
+		},
+		"p2wpkh": {testScriptP2WPKH},
+		"p2wsh":  {testScriptP2WSH},
+		"p2tr":   {testScriptP2TR},
+	}
+	allScripts := [][]byte{
+		testScriptP2WPKH, testScriptP2WSH, testScriptP2TR,
+		testScriptP2PKH, testScriptOpReturn,
+	}
+
+	for i, cfg := range customFilterConfigs {
+		expected := expectedScripts[cfg.name]
+
+		// The duplicate p2wpkh output must only count once, so the
+		// number of filter elements is the number of expected
+		// scripts.
+		require.EqualValues(
+			t, len(expected), filters[i].N(), cfg.name,
+		)
+
+		for _, script := range allScripts {
+			match, err := filters[i].Match(key, script)
+			require.NoError(t, err)
+
+			shouldMatch := false
+			for _, exp := range expected {
+				if bytes.Equal(exp, script) {
+					shouldMatch = true
+				}
+			}
+			require.Equalf(
+				t, shouldMatch, match, "config %s, script %x",
+				cfg.name, script,
+			)
+		}
+	}
+
+	// A block without any matching scripts must produce a valid, empty
+	// filter that still serializes and chains.
+	emptyBlock := &blockWithPrevOuts{
+		txs: []*wire.MsgTx{{
+			TxOut: []*wire.TxOut{{PkScript: testScriptP2PKH}},
+		}},
+	}
+	filters, err = buildCustomFilters(&blockHash, emptyBlock)
+	require.NoError(t, err)
+	for _, filter := range filters {
+		require.EqualValues(t, 0, filter.N())
+
+		nBytes, err := filter.NBytes()
+		require.NoError(t, err)
+		require.Equal(t, []byte{0x00}, nBytes)
+
+		_, err = builder.MakeHeaderForFilter(filter, chainhash.Hash{})
+		require.NoError(t, err)
+	}
+}
+
+// TestCustomFilterFilesUpdate runs the custom filter producer against a real
+// backend, checks the produced filters match the expected scripts, verifies
+// the on-disk filter header chains from genesis and checks that a restart
+// resumes the header chains correctly from disk.
+func TestCustomFilterFilesUpdate(t *testing.T) {
+	miner, backend, backendCfg, _ := setupBackend(t, unitTestDir)
+
+	// Mine initial blocks. The miner starts with 200 blocks already
+	// mined.
+	_ = miner.MineEmptyBlocks(initialBlocks - int(totalStartupBlocks))
+	waitBackendSync(t, backend, miner)
+
+	// First run: start from scratch.
+	dataDir := t.TempDir()
+	quit := make(chan struct{})
+	h2hCache := newH2HCache(backend)
+	cf := newCustomFilterFiles(
+		customBlocksPerFile, customHeadersPerFile, testReOrgSafeDepth,
+		backend, quit, dataDir, &testParams, h2hCache,
+		newBlockPrevOutFetcher(backend, &backendCfg),
+	)
+
+	var wg sync.WaitGroup
+	waitForTargetHeight(t, &wg, cf, initialBlocks)
+
+	// The filter files for the sealed range [0, 399] must exist (tip 450
+	// minus the reorg-safe depth doesn't reach the 400-499 boundary),
+	// along with the single completed header file [0, 299].
+	checkCustomFilterFiles(t, dataDir, 399, 299)
+
+	// Create one output of each custom filter type, plus a legacy p2pkh
+	// control output that must not appear in any custom filter.
+	spendScripts := [][]byte{
+		testScriptP2WPKH, testScriptP2WSH, testScriptP2TR,
+		testScriptP2PKH,
+	}
+	for _, pkScript := range spendScripts {
+		miner.SendOutput(&wire.TxOut{
+			Value:    100_000,
+			PkScript: pkScript,
+		}, 2)
+	}
+
+	minedBlocks := miner.MineBlocksAndAssertNumTxes(1, len(spendScripts))
+	spendHeight := int32(initialBlocks + 1)
+	waitBackendSync(t, backend, miner)
+	waitForTargetHeight(t, &wg, cf, spendHeight)
+
+	// The spend block is still in the unsealed tail, so we check its
+	// filters straight from memory.
+	spendBlockHash := minedBlocks[0].BlockHash()
+	key := builder.DeriveKey(&spendBlockHash)
+
+	cf.RLock()
+	spendFilters := cf.filters[spendHeight]
+	cf.RUnlock()
+	require.Len(t, spendFilters, len(customFilterConfigs))
+
+	assertMatches := func(t *testing.T, filter *gcs.Filter,
+		mask scriptTypes) {
+
+		t.Helper()
+
+		for _, pkScript := range spendScripts {
+			match, err := filter.Match(key, pkScript)
+			require.NoError(t, err)
+			require.Equalf(
+				t, classifyScript(pkScript)&mask != 0, match,
+				"script %x", pkScript,
+			)
+		}
+	}
+
+	for i, cfg := range customFilterConfigs {
+		filter, err := gcs.FromNBytes(
+			builder.DefaultP, builder.DefaultM, spendFilters[i],
+		)
+		require.NoError(t, err)
+
+		assertMatches(t, filter, cfg.types)
+	}
+
+	// Cross-check against the backend: bitcoind's basic filter for the
+	// same block uses the same parameters and key, so it must match all
+	// of our scripts, including the p2pkh one.
+	basicFilter, err := backend.GetBlockFilter(spendBlockHash, &filterBasic)
+	require.NoError(t, err)
+	basicBytes, err := hex.DecodeString(basicFilter.Filter)
+	require.NoError(t, err)
+	basic, err := gcs.FromNBytes(
+		builder.DefaultP, builder.DefaultM, basicBytes,
+	)
+	require.NoError(t, err)
+	for _, pkScript := range spendScripts {
+		match, err := basic.Match(key, pkScript)
+		require.NoError(t, err)
+		require.Truef(t, match, "basic filter, script %x", pkScript)
+	}
+
+	// Stop the service.
+	close(quit)
+	wg.Wait()
+
+	// Second run: restart and continue. The producer resumes at height
+	// 400, in the middle of the header file span [300, 599], so it has
+	// to rebuild the headers of [300, 399] from the sealed filter files
+	// before it can continue the chains.
+	const finalBlocks = 650
+	_ = miner.MineEmptyBlocks(finalBlocks - int(spendHeight))
+	waitBackendSync(t, backend, miner)
+
+	quit = make(chan struct{})
+	cf = newCustomFilterFiles(
+		customBlocksPerFile, customHeadersPerFile, testReOrgSafeDepth,
+		backend, quit, dataDir, &testParams, h2hCache,
+		newBlockPrevOutFetcher(backend, &backendCfg),
+	)
+	waitForTargetHeight(t, &wg, cf, finalBlocks)
+
+	// Filters are now sealed through height 599, which completes the
+	// second header file [300, 599] - partially from rebuilt headers.
+	checkCustomFilterFiles(t, dataDir, 599, 599)
+
+	// Stop the service.
+	close(quit)
+	wg.Wait()
+
+	// Finally, verify every configuration's filter header chain from
+	// genesis across all sealed files, including the span that was
+	// rebuilt after the restart.
+	for _, cfg := range customFilterConfigs {
+		verifyCustomFilterChain(t, dataDir, cfg.name, 599)
+	}
+}
+
+// checkCustomFilterFiles asserts that the sealed custom filter files up to
+// filterEnd and the sealed filter header files up to headerEnd exist for
+// every configuration, that the fixed-size header files have the expected
+// size and that no header file exists beyond headerEnd.
+func checkCustomFilterFiles(t *testing.T, dataDir string, filterEnd,
+	headerEnd int32) {
+
+	t.Helper()
+
+	for _, cfg := range customFilterConfigs {
+		filterDir := filepath.Join(dataDir, customFilterDir(cfg.name))
+		headerDir := filepath.Join(dataDir, customHeaderDir(cfg.name))
+
+		for fileStart := int32(0); fileStart < filterEnd; fileStart += customBlocksPerFile {
+			filterFile := fmt.Sprintf(
+				FilterFileNamePattern, filterDir, fileStart,
+				fileStart+customBlocksPerFile-1,
+			)
+			info, err := os.Stat(filterFile)
+			require.NoError(t, err)
+			require.Positive(t, info.Size())
+		}
+
+		for fileStart := int32(0); fileStart < headerEnd; fileStart += customHeadersPerFile {
+			checkFile(t, fmt.Sprintf(
+				FilterHeaderFileNamePattern, headerDir,
+				fileStart, fileStart+customHeadersPerFile-1,
+			), int64(customHeadersPerFile)*chainhash.HashSize)
+		}
+
+		require.NoFileExists(t, fmt.Sprintf(
+			FilterHeaderFileNamePattern, headerDir, headerEnd+1,
+			headerEnd+customHeadersPerFile,
+		))
+	}
+}
+
+// verifyCustomFilterChain re-computes the BIP-0157 filter header chain of
+// the given configuration from the sealed filter files on disk and asserts
+// it matches the sealed filter header files, starting at the genesis
+// all-zero header up to the given end height (which must be both a filter
+// and a header file boundary).
+func verifyCustomFilterChain(t *testing.T, dataDir, name string,
+	endHeight int32) {
+
+	t.Helper()
+
+	// First re-compute the expected header of every height from the
+	// filter files alone.
+	var prevHeader chainhash.Hash
+	expected := make([]chainhash.Hash, 0, endHeight+1)
+	filterDir := filepath.Join(dataDir, customFilterDir(name))
+	for fileStart := int32(0); fileStart < endHeight; fileStart += customBlocksPerFile {
+		filterFile, err := os.Open(fmt.Sprintf(
+			FilterFileNamePattern, filterDir, fileStart,
+			fileStart+customBlocksPerFile-1,
+		))
+		require.NoError(t, err)
+
+		for range customBlocksPerFile {
+			filterBytes, err := wire.ReadVarBytes(
+				filterFile, 0, wire.MaxMessagePayload,
+				"filter",
+			)
+			require.NoError(t, err)
+
+			// header = double-SHA256(filter_hash || prev_header).
+			filterHash := chainhash.DoubleHashB(filterBytes)
+			prevHeader = chainhash.DoubleHashH(
+				append(filterHash, prevHeader[:]...),
+			)
+			expected = append(expected, prevHeader)
+		}
+
+		require.NoError(t, filterFile.Close())
+	}
+
+	// Then compare them against the contents of the sealed header files.
+	headerDir := filepath.Join(dataDir, customHeaderDir(name))
+	for fileStart := int32(0); fileStart < endHeight; fileStart += customHeadersPerFile {
+		headerBytes, err := os.ReadFile(fmt.Sprintf(
+			FilterHeaderFileNamePattern, headerDir, fileStart,
+			fileStart+customHeadersPerFile-1,
+		))
+		require.NoError(t, err)
+
+		for j := range int32(customHeadersPerFile) {
+			offset := j * chainhash.HashSize
+			require.Equalf(
+				t, expected[fileStart+j][:],
+				headerBytes[offset:offset+chainhash.HashSize],
+				"config %s, height %d", name, fileStart+j,
+			)
+		}
+	}
+}

--- a/handlers.go
+++ b/handlers.go
@@ -200,21 +200,33 @@ func (s *server) statusRequestHandler(w http.ResponseWriter, _ *http.Request) {
 	s.h2hCache.RLock()
 	defer s.h2hCache.RUnlock()
 
-	bestHeight := s.headerFiles.getCurrentHeight()
-	bestBlock, err := s.h2hCache.getBlockHash(bestHeight)
+	status, err := s.currentStatus()
 	if err != nil {
 		sendError(w, status500, errInvalidSyncStatus)
 		return
 	}
 
+	sendJSON(w, status, maxAgeMemory)
+}
+
+// currentStatus assembles the /status response from the current state of the
+// producers. The caller must hold the h2hCache read lock.
+func (s *server) currentStatus() (*Status, error) {
+	bestHeight := s.headerFiles.getCurrentHeight()
+	bestBlock, err := s.h2hCache.getBlockHash(bestHeight)
+	if err != nil {
+		return nil, err
+	}
+
 	bestFilter, ok := s.headerFiles.filterHeaderAtHeight(bestHeight)
 	if !ok {
-		sendError(w, status500, errInvalidSyncStatus)
-		return
+		return nil, fmt.Errorf("no filter header at height %d",
+			bestHeight)
 	}
 
 	var (
 		spHeight     int32
+		customHeight int32
 		filterHeight = s.cFilterFiles.currentHeight.Load()
 		allSynced    = bestHeight == filterHeight
 	)
@@ -223,23 +235,29 @@ func (s *server) statusRequestHandler(w http.ResponseWriter, _ *http.Request) {
 		allSynced = allSynced && bestHeight == spHeight
 	}
 
-	status := &Status{
-		Version:               version,
-		Commit:                Commit,
-		ChainGenesisHash:      s.chainParams.GenesisHash.String(),
-		ChainName:             s.chainParams.Name,
-		BestBlockHeight:       bestHeight,
-		BestBlockHash:         bestBlock.String(),
-		BestFilterHeight:      filterHeight,
-		BestFilterHeader:      bestFilter.String(),
-		BestSPTweakHeight:     spHeight,
-		EntriesPerHeaderFile:  s.headersPerFile,
-		EntriesPerFilterFile:  s.filtersPerFile,
-		EntriesPerSPTweakFile: s.spTweaksPerFile,
-		AllFilesSynced:        allSynced,
+	customAvailable := s.customFilterFiles != nil
+	if customAvailable {
+		customHeight = s.customFilterFiles.currentHeight.Load()
+		allSynced = allSynced && bestHeight == customHeight
 	}
 
-	sendJSON(w, status, maxAgeMemory)
+	return &Status{
+		Version:                version,
+		Commit:                 Commit,
+		ChainGenesisHash:       s.chainParams.GenesisHash.String(),
+		ChainName:              s.chainParams.Name,
+		BestBlockHeight:        bestHeight,
+		BestBlockHash:          bestBlock.String(),
+		BestFilterHeight:       filterHeight,
+		BestFilterHeader:       bestFilter.String(),
+		BestSPTweakHeight:      spHeight,
+		CustomFiltersAvailable: customAvailable,
+		BestCustomFilterHeight: customHeight,
+		EntriesPerHeaderFile:   s.headersPerFile,
+		EntriesPerFilterFile:   s.filtersPerFile,
+		EntriesPerSPTweakFile:  s.spTweaksPerFile,
+		AllFilesSynced:         allSynced,
+	}, nil
 }
 
 func (s *server) headersRequestHandler(w http.ResponseWriter, r *http.Request) {

--- a/handlers.go
+++ b/handlers.go
@@ -55,6 +55,18 @@ var (
 		"SP tweak data indexing is turned off",
 	)
 
+	// errUnavailableCustomFiltersTurnedOff is an error indicating that
+	// the custom filter indexing is turned off.
+	errUnavailableCustomFiltersTurnedOff = errors.New(
+		"custom filter indexing is turned off",
+	)
+
+	// errUnknownCustomFilterType is an error indicating that the
+	// requested custom filter type doesn't exist.
+	errUnknownCustomFilterType = errors.New(
+		"unknown custom filter type",
+	)
+
 	// errStillStartingUp is an error indicating that the server is still
 	// starting up and not ready to serve requests yet.
 	errStillStartingUp = errors.New(
@@ -139,10 +151,18 @@ func (s *server) createRouter() *mux.Router {
 		"/filter-headers/import/{height:[0-9]+}",
 		s.filterHeadersImportRequestHandler,
 	)
+	router.HandleFunc(
+		"/filter-headers/type/{filterType}/{height:[0-9]+}",
+		s.customFilterHeadersRequestHandler,
+	)
 	router.HandleFunc("/filters/{height:[0-9]+}", s.filtersRequestHandler)
 	router.HandleFunc(
 		"/filters/single/{height:[0-9]+}",
 		s.filterSingleRequestHandler,
+	)
+	router.HandleFunc(
+		"/filters/type/{filterType}/{height:[0-9]+}",
+		s.customFiltersRequestHandler,
 	)
 	router.HandleFunc(
 		"/sp/tweak-data/{height:[0-9]+}",
@@ -291,6 +311,82 @@ func (s *server) filtersRequestHandler(w http.ResponseWriter, r *http.Request) {
 		w, r, FilterFileDir, FilterFileNamePattern,
 		int64(s.filtersPerFile), s.cFilterFiles.serializeFilters,
 		s.cFilterFiles.filtersSize, s.cFilterFiles,
+	)
+}
+
+// customFilterConfig resolves the {filterType} route variable to a custom
+// filter configuration index, writing the appropriate error response if the
+// custom filter producer isn't running or the type doesn't exist.
+func (s *server) customFilterConfig(w http.ResponseWriter,
+	r *http.Request) (string, int, bool) {
+
+	if s.customFilterFiles == nil {
+		sendError(w, status503, errUnavailableCustomFiltersTurnedOff)
+		return "", 0, false
+	}
+
+	filterType := mux.Vars(r)["filterType"]
+	cfgIndex, ok := customFilterConfigIndex(filterType)
+	if !ok {
+		err := fmt.Errorf("%w: %s", errUnknownCustomFilterType,
+			filterType)
+		sendError(w, status400, err)
+		return "", 0, false
+	}
+
+	return filterType, cfgIndex, true
+}
+
+// customFiltersRequestHandler serves /filters/type/{filterType}/{height}:
+// the batched filter files of one output-type-restricted filter set, in the
+// same format as the basic /filters/{height} endpoint.
+func (s *server) customFiltersRequestHandler(w http.ResponseWriter,
+	r *http.Request) {
+
+	filterType, cfgIndex, ok := s.customFilterConfig(w, r)
+	if !ok {
+		return
+	}
+
+	s.heightBasedRequestHandler(
+		w, r, customFilterDir(filterType), FilterFileNamePattern,
+		int64(s.filtersPerFile),
+		func(w io.Writer, startIndex, endIndex int32) error {
+			return s.customFilterFiles.serializeFilters(
+				w, cfgIndex, startIndex, endIndex,
+			)
+		},
+		func(startIndex, endIndex int32) (int64, bool) {
+			return s.customFilterFiles.filtersSize(
+				cfgIndex, startIndex, endIndex,
+			)
+		},
+		s.customFilterFiles,
+	)
+}
+
+// customFilterHeadersRequestHandler serves the endpoint
+// /filter-headers/type/{filterType}/{height}: the batched filter header
+// files of one output-type-restricted filter set, in the same format (and
+// with the same entries per file) as the basic /filter-headers/{height}
+// endpoint.
+func (s *server) customFilterHeadersRequestHandler(w http.ResponseWriter,
+	r *http.Request) {
+
+	filterType, cfgIndex, ok := s.customFilterConfig(w, r)
+	if !ok {
+		return
+	}
+
+	s.heightBasedRequestHandler(
+		w, r, customHeaderDir(filterType), FilterHeaderFileNamePattern,
+		int64(s.headersPerFile),
+		func(w io.Writer, startIndex, endIndex int32) error {
+			return s.customFilterFiles.serializeFilterHeaders(
+				w, cfgIndex, startIndex, endIndex,
+			)
+		},
+		s.customFilterFiles.filterHeadersSize, s.customFilterFiles,
 	)
 }
 

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -261,4 +262,62 @@ func TestFilterSingleMemoryPath(t *testing.T) {
 			t, rec.Body.String(), "greater than current height",
 		)
 	})
+}
+
+// TestCurrentStatus checks the /status response assembly, in particular the
+// custom filter fields and their effect on all_files_synced.
+func TestCurrentStatus(t *testing.T) {
+	const tip = int32(42)
+
+	h2h := newH2HCache(nil)
+	h2h.heightToHash[tip] = chainhash.Hash{0x01}
+	h2h.bestHeight.Store(tip)
+
+	s := &server{
+		chainParams: &testParams,
+		h2hCache:    h2h,
+		headerFiles: newHeaderFiles(
+			100, 6, nil, nil, "", &testParams, h2h,
+		),
+		cFilterFiles: newCFilterFiles(
+			100, 6, nil, nil, "", &testParams, h2h,
+		),
+	}
+	s.headerFiles.currentHeight.Store(tip)
+	s.headerFiles.filterHeaders[tip] = chainhash.Hash{0x02}
+	s.cFilterFiles.currentHeight.Store(tip)
+
+	// currentStatus expects the h2hCache read lock to be held.
+	s.h2hCache.RLock()
+	defer s.h2hCache.RUnlock()
+
+	// Without the custom filter producer running, the status must report
+	// custom filters as unavailable and ignore them for the sync flag.
+	status, err := s.currentStatus()
+	require.NoError(t, err)
+	require.False(t, status.CustomFiltersAvailable)
+	require.EqualValues(t, 0, status.BestCustomFilterHeight)
+	require.True(t, status.AllFilesSynced)
+
+	// A synced custom filter producer is reported with its height and
+	// keeps the sync flag intact.
+	s.customFilterFiles = newCustomFilterFiles(
+		100, 200, 6, nil, nil, "", &testParams, h2h, nil,
+	)
+	s.customFilterFiles.currentHeight.Store(tip)
+
+	status, err = s.currentStatus()
+	require.NoError(t, err)
+	require.True(t, status.CustomFiltersAvailable)
+	require.Equal(t, tip, status.BestCustomFilterHeight)
+	require.True(t, status.AllFilesSynced)
+
+	// A lagging custom filter producer must flip the sync flag.
+	s.customFilterFiles.currentHeight.Store(tip - 1)
+
+	status, err = s.currentStatus()
+	require.NoError(t, err)
+	require.True(t, status.CustomFiltersAvailable)
+	require.Equal(t, tip-1, status.BestCustomFilterHeight)
+	require.False(t, status.AllFilesSynced)
 }

--- a/header-files_test.go
+++ b/header-files_test.go
@@ -28,7 +28,7 @@ const (
 )
 
 func TestHeaderFilesUpdate(t *testing.T) {
-	miner, backend, _, _ := setupBackend(t, unitTestDir)
+	miner, backend, _, _ := setupBackend(t)
 
 	// Mine initial blocks. The miner starts with 438 blocks already mined.
 	_ = miner.MineEmptyBlocks(initialBlocks - int(totalStartupBlocks))

--- a/index.html
+++ b/index.html
@@ -239,6 +239,25 @@
                 </td>
             </tr>
             <tr>
+                <td>
+                    <code>/filter-headers/type/&lt;filter_type&gt;/&lt;start_block&gt;</code>
+                </td>
+                <td>
+                    Returns a binary file containing 100'000 compact filter
+                    headers of one of the output-type-restricted filter sets
+                    (<code>segwit</code> [combination of all three following
+                    types], <code>p2wpkh</code>,
+                    <code>p2wsh</code> or <code>p2tr</code>), serialized the
+                    same way as <code>/filter-headers</code>. Only available
+                    if the server indexes custom filters.
+                </td>
+                <td>
+                    <a href="https://block-dn.org/filter-headers/type/segwit/100000">
+                        block-dn.org/filter-headers/type/segwit/100000
+                    </a>
+                </td>
+            </tr>
+            <tr>
                 <td><code>/filters/&lt;start_block&gt;</code></td>
                 <td>
                     Returns a binary file containing 2'000 compact filters,
@@ -268,6 +287,28 @@
                 <td>
                     <a href="https://block-dn.org/filters/single/802123">
                         block-dn.org/filters/single/802123
+                    </a>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <code>/filters/type/&lt;filter_type&gt;/&lt;start_block&gt;</code>
+                </td>
+                <td>
+                    Returns a binary file containing 2'000 compact filters of
+                    one of the output-type-restricted filter sets
+                    (<code>segwit</code> [combination of all three following
+                    types], <code>p2wpkh</code>,
+                    <code>p2wsh</code> or <code>p2tr</code>), serialized the
+                    same way as <code>/filters</code>. These filters use the
+                    same parameters as the BIP-0158 basic filters but only
+                    include output scripts of the given types, making them
+                    significantly smaller. Only available if the server
+                    indexes custom filters.
+                </td>
+                <td>
+                    <a href="https://block-dn.org/filters/type/segwit/802000">
+                        block-dn.org/filters/type/segwit/802000
                     </a>
                 </td>
             </tr>

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	version = "1.3.4"
+	version = "1.4.0"
 
 	defaultListenPort = 8080
 

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ type mainCommand struct {
 
 	lightMode           bool
 	indexSPTweakData    bool
+	indexCustomFilters  bool
 	prevOutCacheSizeMiB uint16
 
 	baseDir   string
@@ -148,7 +149,8 @@ func main() {
 			}
 
 			server := newServer(
-				cc.lightMode, cc.indexSPTweakData, cc.baseDir,
+				cc.lightMode, cc.indexSPTweakData,
+				cc.indexCustomFilters, cc.baseDir,
 				cc.listenAddr, cc.bitcoindConfig, chainParams,
 				cc.reOrgSafeDepth, headersPerFile,
 				filtersPerFile, spTweaksPerFile,
@@ -214,6 +216,14 @@ func main() {
 			"Taproot to be indexed which may take a while; "+
 			"requires bitcoind v30.0 or later with the REST API "+
 			"enabled (rest=1)",
+	)
+	cc.cmd.PersistentFlags().BoolVar(
+		&cc.indexCustomFilters, "index-custom-filters", false,
+		"Indicates if the server should build custom "+
+			"output-type-restricted compact filters (four sets: "+
+			"segwit, p2wpkh, p2wsh, p2tr); adds about 8 GB more "+
+			"data as of block 950k; requires bitcoind v30.0 or "+
+			"later with the REST API enabled (rest=1)",
 	)
 	cc.cmd.PersistentFlags().Uint16Var(
 		&cc.prevOutCacheSizeMiB, "prev-out-cache-size-mib", 1024,

--- a/main_test.go
+++ b/main_test.go
@@ -10,12 +10,15 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil/v2/gcs"
+	"github.com/btcsuite/btcd/btcutil/v2/gcs/builder"
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/psbt/v2"
@@ -181,6 +184,12 @@ func (ctx *testContext) waitFilesSync(t *testing.T) {
 				headerHeight)
 		}
 
+		customHeight := ctx.server.customFilterFiles.getCurrentHeight()
+		if headerHeight != customHeight {
+			return fmt.Errorf("custom filter height mismatch: "+
+				"%d vs %d", customHeight, headerHeight)
+		}
+
 		return nil
 	}, syncTimeout)
 	require.NoError(t, err)
@@ -260,6 +269,18 @@ var testCases = []struct {
 		name: "fees-estimate",
 		fn:   testFeeEstimate,
 	},
+
+	// The custom filter tests mine additional blocks, so they run last
+	// to not interfere with the tip-height assumptions of the cases
+	// above.
+	{
+		name: "custom-filters",
+		fn:   testCustomFilters,
+	},
+	{
+		name: "custom-filter-headers",
+		fn:   testCustomFilterHeaders,
+	},
 }
 
 func testErrors(t *testing.T, ctx *testContext) {
@@ -323,6 +344,10 @@ func testErrors(t *testing.T, ctx *testContext) {
 			status: 404,
 			error:  "404 page not found",
 		}
+		respBadFilterType = errorResponse{
+			status: 400,
+			error:  "unknown custom filter type: bogus",
+		}
 	)
 	errorCases := map[string]errorResponse{
 		"foo":                                   respNotFound,
@@ -348,6 +373,12 @@ func testErrors(t *testing.T, ctx *testContext) {
 		"filters/" + badInt64:                   respBadHeight,
 		"filters/1":                             respBadStartHeight1,
 		"filters/" + badStartHeight:             respBadStartHeightLarge,
+		"filters/type/segwit":                   respNotFound,
+		"filters/type/bogus/0":                  respBadFilterType,
+		"filters/type/segwit/1":                 respBadStartHeight1,
+		"filter-headers/type/segwit":            respNotFound,
+		"filter-headers/type/bogus/0":           respBadFilterType,
+		"filter-headers/type/segwit/1":          respBadStartHeight1,
 		"block":                                 respNotFound,
 		"block/aaaa":                            respBadHashLength,
 		"block/" + badHash:                      respNotFound,
@@ -991,7 +1022,7 @@ func TestBlockDN(t *testing.T) {
 	// Activate Taproot for regtest.
 	TaprootActivationHeights[chaincfg.RegressionNetParams.Net] = 1
 
-	miner, backend, backendCfg, _ := setupBackend(t, unitTestDir)
+	miner, backend, backendCfg, _ := setupBackend(t)
 
 	dataDir := t.TempDir()
 	listenAddr := fmt.Sprintf("127.0.0.1:%d", port.NextAvailablePort())
@@ -1119,9 +1150,155 @@ func newBitcoind(t *testing.T, logdir string,
 }
 
 // nolint:unparam
-func setupBackend(t *testing.T, testDir string) (*lntestminer.HarnessMiner,
+// testCustomFilters exercises the /filters/type/<name>/<height> endpoint:
+// sealed files served from disk, the unsealed tail served from memory and
+// the filter content of a block with known outputs.
+func testCustomFilters(t *testing.T, ctx *testContext) {
+	// Create one output of each custom filter type, so the tip block
+	// contains known scripts, then mine and wait for the files to sync.
+	spendScripts := [][]byte{
+		testScriptP2WPKH, testScriptP2WSH, testScriptP2TR,
+	}
+	for _, pkScript := range spendScripts {
+		ctx.miner.SendOutput(&wire.TxOut{
+			Value:    100_000,
+			PkScript: pkScript,
+		}, 2)
+	}
+	minedBlocks := ctx.miner.MineBlocksAndAssertNumTxes(
+		1, len(spendScripts),
+	)
+	ctx.waitBackendSync(t)
+	ctx.waitFilesSync(t)
+
+	tipHash := minedBlocks[0].BlockHash()
+	key := builder.DeriveKey(&tipHash)
+	tipHeight := int(ctx.server.customFilterFiles.getCurrentHeight())
+
+	for _, cfg := range customFilterConfigs {
+		// The first file is sealed and must be served from disk.
+		body, headers := ctx.fetchBinary(
+			t, fmt.Sprintf("filters/type/%s/0", cfg.name),
+		)
+		filters := parseVarIntPrefixedList(t, body)
+		require.Len(t, filters, DefaultRegtestFiltersPerFile)
+		require.Equal(t, cacheDisk, headers.Get(HeaderCache))
+		require.Equal(t, "*", headers.Get(HeaderCORS))
+
+		// The unsealed tail is served from memory.
+		body, headers = ctx.fetchBinary(t, fmt.Sprintf(
+			"filters/type/%s/%d", cfg.name,
+			DefaultRegtestFiltersPerFile,
+		))
+		tail := parseVarIntPrefixedList(t, body)
+		require.Len(t, tail, tipHeight-DefaultRegtestFiltersPerFile+1)
+		require.Equal(t, cacheMemory, headers.Get(HeaderCache))
+		require.Equal(t, "*", headers.Get(HeaderCORS))
+
+		// The tip block's filter must match exactly the scripts of
+		// the set's types.
+		tipFilter, err := gcs.FromNBytes(
+			builder.DefaultP, builder.DefaultM, tail[len(tail)-1],
+		)
+		require.NoError(t, err)
+
+		for _, pkScript := range spendScripts {
+			match, err := tipFilter.Match(key, pkScript)
+			require.NoError(t, err)
+			require.Equalf(
+				t, classifyScript(pkScript)&cfg.types != 0,
+				match, "filter %s, script %x", cfg.name,
+				pkScript,
+			)
+		}
+	}
+}
+
+// testCustomFilterHeaders exercises the endpoint
+// /filter-headers/type/<name>/<height> and cross-checks the served header
+// chains against the filters served by /filters/type/<name>/<height>.
+func testCustomFilterHeaders(t *testing.T, ctx *testContext) {
+	tipHeight := int(ctx.server.customFilterFiles.getCurrentHeight())
+
+	for _, cfg := range customFilterConfigs {
+		// The first file is sealed and must be served from disk.
+		body, headers := ctx.fetchBinary(t, fmt.Sprintf(
+			"filter-headers/type/%s/0", cfg.name,
+		))
+		require.Len(
+			t, body,
+			DefaultRegtestHeadersPerFile*chainhash.HashSize,
+		)
+		require.Equal(t, cacheDisk, headers.Get(HeaderCache))
+		require.Equal(t, "*", headers.Get(HeaderCORS))
+
+		// The unsealed tail is served from memory.
+		tailBody, tailHeaders := ctx.fetchBinary(t, fmt.Sprintf(
+			"filter-headers/type/%s/%d", cfg.name,
+			DefaultRegtestHeadersPerFile,
+		))
+		expectedLen := (tipHeight - DefaultRegtestHeadersPerFile + 1) *
+			chainhash.HashSize
+		require.Len(t, tailBody, expectedLen)
+		require.Equal(t, cacheMemory, tailHeaders.Get(HeaderCache))
+		require.Equal(t, "*", tailHeaders.Get(HeaderCORS))
+
+		headerBytes := slices.Concat(body, tailBody)
+
+		// Re-compute the whole chain from the filters endpoint and
+		// compare every height's header:
+		// header = dsha256(dsha256(filter) || prev_header).
+		filterBody, _ := ctx.fetchBinary(
+			t, fmt.Sprintf("filters/type/%s/0", cfg.name),
+		)
+		filterTail, _ := ctx.fetchBinary(t, fmt.Sprintf(
+			"filters/type/%s/%d", cfg.name,
+			DefaultRegtestFiltersPerFile,
+		))
+		filters := parseVarIntPrefixedList(
+			t, slices.Concat(filterBody, filterTail),
+		)
+		require.Len(t, filters, tipHeight+1)
+
+		var prevHeader chainhash.Hash
+		for i, filterBytes := range filters {
+			filterHash := chainhash.DoubleHashB(filterBytes)
+			prevHeader = chainhash.DoubleHashH(
+				append(filterHash, prevHeader[:]...),
+			)
+
+			offset := i * chainhash.HashSize
+			require.Equalf(
+				t, prevHeader[:],
+				headerBytes[offset:offset+chainhash.HashSize],
+				"filter %s, height %d", cfg.name, i,
+			)
+		}
+	}
+}
+
+// parseVarIntPrefixedList splits a response body consisting of var-int
+// length prefixed entries into the individual entries.
+func parseVarIntPrefixedList(t *testing.T, body []byte) [][]byte {
+	t.Helper()
+
+	reader := bytes.NewReader(body)
+	var entries [][]byte
+	for reader.Len() > 0 {
+		entry, err := wire.ReadVarBytes(
+			reader, 0, wire.MaxMessagePayload, "entry",
+		)
+		require.NoError(t, err)
+		entries = append(entries, entry)
+	}
+
+	return entries
+}
+
+func setupBackend(t *testing.T) (*lntestminer.HarnessMiner,
 	*rpcclient.Client, rpcclient.ConnConfig, *chain.BitcoindConfig) {
 
+	testDir := unitTestDir
 	ctx := context.Background()
 	setupLogging(testDir, "debug")
 

--- a/main_test.go
+++ b/main_test.go
@@ -997,7 +997,7 @@ func TestBlockDN(t *testing.T) {
 	listenAddr := fmt.Sprintf("127.0.0.1:%d", port.NextAvailablePort())
 
 	testServer := newServer(
-		false, true, dataDir, listenAddr, &backendCfg,
+		false, true, true, dataDir, listenAddr, &backendCfg,
 		unittest.NetParams, 6, DefaultRegtestHeadersPerFile,
 		DefaultRegtestFiltersPerFile, DefaultRegtestSPTweaksPerFile,
 		defaultReadTimeout, defaultWriteTimeout,

--- a/main_test.go
+++ b/main_test.go
@@ -463,6 +463,8 @@ func testStatus(t *testing.T, ctx *testContext) {
 	require.Equal(t, height, status.BestBlockHeight)
 	require.Equal(t, height, status.BestFilterHeight)
 	require.Equal(t, height, status.BestSPTweakHeight)
+	require.True(t, status.CustomFiltersAvailable)
+	require.Equal(t, height, status.BestCustomFilterHeight)
 	require.Equal(t, blockHash.String(), status.BestBlockHash)
 
 	filterHeader, ok := ctx.server.headerFiles.filterHeaderAtHeight(height)

--- a/models.go
+++ b/models.go
@@ -3,19 +3,21 @@ package main
 import "fmt"
 
 type Status struct {
-	Version               string `json:"version"`
-	Commit                string `json:"commit"`
-	ChainGenesisHash      string `json:"chain_genesis_hash"`
-	ChainName             string `json:"chain_name"`
-	BestBlockHeight       int32  `json:"best_block_height"`
-	BestBlockHash         string `json:"best_block_hash"`
-	BestFilterHeader      string `json:"best_filter_header"`
-	BestFilterHeight      int32  `json:"best_filter_height"`
-	BestSPTweakHeight     int32  `json:"best_sptweak_height"`
-	AllFilesSynced        bool   `json:"all_files_synced"`
-	EntriesPerHeaderFile  int32  `json:"entries_per_header_file"`
-	EntriesPerFilterFile  int32  `json:"entries_per_filter_file"`
-	EntriesPerSPTweakFile int32  `json:"entries_per_sptweak_file"`
+	Version                string `json:"version"`
+	Commit                 string `json:"commit"`
+	ChainGenesisHash       string `json:"chain_genesis_hash"`
+	ChainName              string `json:"chain_name"`
+	BestBlockHeight        int32  `json:"best_block_height"`
+	BestBlockHash          string `json:"best_block_hash"`
+	BestFilterHeader       string `json:"best_filter_header"`
+	BestFilterHeight       int32  `json:"best_filter_height"`
+	BestSPTweakHeight      int32  `json:"best_sptweak_height"`
+	CustomFiltersAvailable bool   `json:"custom_filters_available"`
+	BestCustomFilterHeight int32  `json:"best_custom_filter_height"`
+	AllFilesSynced         bool   `json:"all_files_synced"`
+	EntriesPerHeaderFile   int32  `json:"entries_per_header_file"`
+	EntriesPerFilterFile   int32  `json:"entries_per_filter_file"`
+	EntriesPerSPTweakFile  int32  `json:"entries_per_sptweak_file"`
 }
 
 type FeeRate struct {

--- a/reorg_safe_test.go
+++ b/reorg_safe_test.go
@@ -112,7 +112,7 @@ func startReorgTestServer(t *testing.T,
 	// something to do; matches TestBlockDN's setup.
 	TaprootActivationHeights[chaincfg.RegressionNetParams.Net] = 1
 
-	miner, backend, backendCfg, _ := setupBackend(t, unitTestDir)
+	miner, backend, backendCfg, _ := setupBackend(t)
 	dataDir := t.TempDir()
 	listenAddr := fmt.Sprintf("127.0.0.1:%d", port.NextAvailablePort())
 

--- a/reorg_safe_test.go
+++ b/reorg_safe_test.go
@@ -117,7 +117,7 @@ func startReorgTestServer(t *testing.T,
 	listenAddr := fmt.Sprintf("127.0.0.1:%d", port.NextAvailablePort())
 
 	srv := newServer(
-		false, true, dataDir, listenAddr, &backendCfg,
+		false, true, true, dataDir, listenAddr, &backendCfg,
 		unittest.NetParams, params.reOrgSafeDepth,
 		params.headersPerFile, params.filtersPerFile,
 		params.spTweaksPerFile,

--- a/server.go
+++ b/server.go
@@ -37,37 +37,39 @@ var (
 )
 
 type server struct {
-	lightMode        bool
-	indexSPTweakData bool
-	baseDir          string
-	listenAddr       string
-	chainCfg         *rpcclient.ConnConfig
-	chainParams      *chaincfg.Params
-	reOrgSafeDepth   uint32
-	readTimeout      time.Duration
-	writeTimeout     time.Duration
-	chain            *rpcclient.Client
-	router           *mux.Router
-	httpServer       *http.Server
+	lightMode          bool
+	indexSPTweakData   bool
+	indexCustomFilters bool
+	baseDir            string
+	listenAddr         string
+	chainCfg           *rpcclient.ConnConfig
+	chainParams        *chaincfg.Params
+	reOrgSafeDepth     uint32
+	readTimeout        time.Duration
+	writeTimeout       time.Duration
+	chain              *rpcclient.Client
+	router             *mux.Router
+	httpServer         *http.Server
 
 	headersPerFile  int32
 	filtersPerFile  int32
 	spTweaksPerFile int32
 
-	h2hCache     *heightToHashCache
-	headerFiles  *headerFiles
-	cFilterFiles *cFilterFiles
-	spTweakFiles *spTweakFiles
+	h2hCache          *heightToHashCache
+	headerFiles       *headerFiles
+	cFilterFiles      *cFilterFiles
+	spTweakFiles      *spTweakFiles
+	customFilterFiles *customFilterFiles
 
 	wg   sync.WaitGroup
 	errs *fn.ConcurrentQueue[error]
 	quit chan struct{}
 }
 
-func newServer(lightMode, indexSPTweakData bool, baseDir, listenAddr string,
-	chainCfg *rpcclient.ConnConfig, chainParams *chaincfg.Params,
-	reOrgSafeDepth uint32, headersPerFile, filtersPerFile,
-	spTweaksPerFile int32, readTimeout,
+func newServer(lightMode, indexSPTweakData, indexCustomFilters bool, baseDir,
+	listenAddr string, chainCfg *rpcclient.ConnConfig,
+	chainParams *chaincfg.Params, reOrgSafeDepth uint32, headersPerFile,
+	filtersPerFile, spTweaksPerFile int32, readTimeout,
 	writeTimeout time.Duration) *server {
 
 	// A zero timeout would disable the protection entirely; fall back to
@@ -80,15 +82,16 @@ func newServer(lightMode, indexSPTweakData bool, baseDir, listenAddr string,
 	}
 
 	s := &server{
-		lightMode:        lightMode,
-		indexSPTweakData: indexSPTweakData,
-		baseDir:          baseDir,
-		listenAddr:       listenAddr,
-		chainCfg:         chainCfg,
-		chainParams:      chainParams,
-		reOrgSafeDepth:   reOrgSafeDepth,
-		readTimeout:      readTimeout,
-		writeTimeout:     writeTimeout,
+		lightMode:          lightMode,
+		indexSPTweakData:   indexSPTweakData,
+		indexCustomFilters: indexCustomFilters,
+		baseDir:            baseDir,
+		listenAddr:         listenAddr,
+		chainCfg:           chainCfg,
+		chainParams:        chainParams,
+		reOrgSafeDepth:     reOrgSafeDepth,
+		readTimeout:        readTimeout,
+		writeTimeout:       writeTimeout,
 
 		headersPerFile:  headersPerFile,
 		filtersPerFile:  filtersPerFile,
@@ -103,16 +106,17 @@ func newServer(lightMode, indexSPTweakData bool, baseDir, listenAddr string,
 	return s
 }
 
-// checkSPTweakBackend verifies that the connected backend meets the
-// requirements for indexing SP tweak data: bitcoind v30.0 or later with the
-// REST API enabled.
-func (s *server) checkSPTweakBackend(fetcher *blockPrevOutFetcher) error {
+// checkPrevOutBackend verifies that the connected backend meets the
+// requirements for indexing data derived from previous outputs (SP tweak
+// data and custom filters): bitcoind v30.0 or later with the REST API
+// enabled.
+func (s *server) checkPrevOutBackend(fetcher *blockPrevOutFetcher) error {
 	info, err := s.chain.GetNetworkInfo()
 	if err != nil {
 		return fmt.Errorf("error querying backend version: %w", err)
 	}
 
-	if err := verifySPTweakBackendVersion(info.Version); err != nil {
+	if err := verifyPrevOutBackendVersion(info.Version); err != nil {
 		return err
 	}
 
@@ -126,13 +130,15 @@ func (s *server) start() error {
 	}
 	s.chain = client
 
-	// Indexing SP tweak data needs the backend's undo data, which is only
-	// served through the REST API of bitcoind v30.0 or later. We verify
-	// both requirements up front, so a misconfigured backend fails the
-	// startup instead of surfacing an error mid-catch-up.
+	// Indexing SP tweak data or custom filters needs the backend's undo
+	// data, which is only served through the REST API of bitcoind v30.0
+	// or later. We verify both requirements up front, so a misconfigured
+	// backend fails the startup instead of surfacing an error
+	// mid-catch-up.
 	blockFetcher := newBlockPrevOutFetcher(s.chain, s.chainCfg)
-	if s.indexSPTweakData && !s.lightMode {
-		if err := s.checkSPTweakBackend(blockFetcher); err != nil {
+	needPrevOuts := s.indexSPTweakData || s.indexCustomFilters
+	if needPrevOuts && !s.lightMode {
+		if err := s.checkPrevOutBackend(blockFetcher); err != nil {
 			return err
 		}
 	}
@@ -245,31 +251,57 @@ func (s *server) start() error {
 		}
 	}()
 
-	// If we're not indexing SP tweak data, we can return here.
-	if !s.indexSPTweakData {
-		return nil
+	if s.indexSPTweakData {
+		s.spTweakFiles = newSPTweakFiles(
+			s.spTweaksPerFile, int32(s.reOrgSafeDepth), s.chain,
+			s.quit, s.baseDir, s.chainParams, s.h2hCache,
+			blockFetcher,
+		)
+
+		s.wg.Add(1)
+		go func() {
+			defer func() {
+				s.wg.Done()
+				log.Infof("Background SP tweak data file " +
+					"update finished")
+			}()
+
+			log.Infof("Starting background SP tweak data file " +
+				"update")
+			err := s.spTweakFiles.updateFiles(info.Blocks)
+			if err != nil && !errors.Is(err, errServerShutdown) {
+				log.Errorf("Error updating SP tweak data "+
+					"file: %v", err)
+				s.errs.ChanIn() <- err
+			}
+		}()
 	}
 
-	s.spTweakFiles = newSPTweakFiles(
-		s.spTweaksPerFile, int32(s.reOrgSafeDepth), s.chain, s.quit,
-		s.baseDir, s.chainParams, s.h2hCache, blockFetcher,
-	)
+	if s.indexCustomFilters {
+		s.customFilterFiles = newCustomFilterFiles(
+			s.filtersPerFile, s.headersPerFile,
+			int32(s.reOrgSafeDepth), s.chain, s.quit, s.baseDir,
+			s.chainParams, s.h2hCache, blockFetcher,
+		)
 
-	s.wg.Add(1)
-	go func() {
-		defer func() {
-			s.wg.Done()
-			log.Infof("Background SP tweak data file update " +
-				"finished")
+		s.wg.Add(1)
+		go func() {
+			defer func() {
+				s.wg.Done()
+				log.Infof("Background custom filter file " +
+					"update finished")
+			}()
+
+			log.Infof("Starting background custom filter file " +
+				"update")
+			err := s.customFilterFiles.updateFiles(info.Blocks)
+			if err != nil && !errors.Is(err, errServerShutdown) {
+				log.Errorf("Error updating custom filter "+
+					"files: %v", err)
+				s.errs.ChanIn() <- err
+			}
 		}()
-
-		log.Infof("Starting background SP tweak data file update")
-		err := s.spTweakFiles.updateFiles(info.Blocks)
-		if err != nil && !errors.Is(err, errServerShutdown) {
-			log.Errorf("Error updating SP tweak data file: %v", err)
-			s.errs.ChanIn() <- err
-		}
-	}()
+	}
 
 	return nil
 }

--- a/silent-payments-files_test.go
+++ b/silent-payments-files_test.go
@@ -72,7 +72,7 @@ func TestSPTweakDataFilesUpdate(t *testing.T) {
 	// Activate Taproot for regtest.
 	TaprootActivationHeights[chaincfg.RegressionNetParams.Net] = 1
 
-	miner, backend, backendCfg, _ := setupBackend(t, unitTestDir)
+	miner, backend, backendCfg, _ := setupBackend(t)
 
 	// Mine initial blocks. The miner starts with 200 blocks already mined.
 	_ = miner.MineEmptyBlocks(initialBlocks - int(totalStartupBlocks))
@@ -154,7 +154,7 @@ func TestSilentPaymentsDetection(t *testing.T) {
 	// Activate Taproot for regtest.
 	TaprootActivationHeights[chaincfg.RegressionNetParams.Net] = 1
 
-	miner, backend, backendCfg, bitcoindCfg := setupBackend(t, unitTestDir)
+	miner, backend, backendCfg, bitcoindCfg := setupBackend(t)
 	wallet, scopeMgr := newTestWallet(
 		t, &testParams, bitcoindCfg, seedBytes,
 	)


### PR DESCRIPTION
Fixes https://github.com/guggero/block-dn/issues/22.

Adds two new REST endpoints: `/filter-headers/type/{filterType}/{height:[0-9]+}` and `/filters/type/{filterType}/{height:[0-9]+}` with custom compact filters that only contain a certain output type (or combination of output types).